### PR TITLE
Ft payl initial payload proc functions

### DIFF
--- a/payload-processing/payload_processing.c
+++ b/payload-processing/payload_processing.c
@@ -1,35 +1,73 @@
+/*  payload_processing.c
+
+	Main entry point for functions controlling and interacting with the
+	experimental Melanin-Dosimeter Payload boards.
+
+	Created by Tyrel Kostyk on February 11th 2020
+ */
 
 
 #include <housekeeping/i2c.h>
 #include <housekeeping/memory.h>
 
-// request a reading from one channel
+
+//==============================================================================
+//                                   GLOBALS
+//==============================================================================
+
+uint8_t dosimeterBoardSlaveAddr[2] = {
+	0x90,  // board one - 1001.0000
+	0x92   // board two - 1001.0010
+};
+
+
+uint8_t dosimeterCommandBytes[8] = {
+	0x84,     // 0 - 1000.0100
+	0xC4,     // 1 - 1100.0100
+	0x94,     // 2 - 1001.0100
+	0xD4,     // 3 - 1101.0100
+	0xA4,     // 4 - 1010.0100
+	0xE4,     // 5 - 1110.0100
+	0xB4,     // 6 - 1011.0100
+	0xF4      // 7 - 1111.0100
+};
+
+
+//==============================================================================
+//                                  FUNCTIONS
+//==============================================================================
+
+// request a reading from all channels
 void requestReadingsAllChannels( void )
 {
-  for (int board = 0; board < 2; board++) {
-    // iterate through both boards
+	// iterate through both melanin-dosimeter boards
+	for ( uint8_t dosimeterBoard = 0; dosimeterBoard < 2; dosimeterBoard++ ) {
 
-    for (int channel = 0; channel < 8; channel++) {
-      // write command to dosimeter board using i2c
-      uint8_t result = i2c->writeByte(dosimeterBoardSlaveAddrsWrite[board], dosimeterCommandBytes[channel]);
+    	// request data from each sensor on a particular board
+		for ( uint8_t adcChannel = 0; adcChannel < 8; adcChannel++ ) {
 
-      if ( result ) {
-        // 0 = failure
-        ASSERT("ERROR");
-      }
+	      // write command to dosimeter board using i2c
+		  uint8_t i2cResult = i2c->writeByte( dosimeterBoardSlaveAddr[dosimeterBoard], dosimeterCommandBytes[adcChannel] );
 
-      // write recieve command over i2c to board
-      uint8_t conversionResultByteHigh = i2c->readByte(dosimeterBoardSlaveAddrsRead[board]);
-      uint8_t conversionResultByteLow = i2c->readByte(dosimeterBoardSlaveAddrsRead[board]);
+	      if ( i2cResult == 0 ) {
+	        // 0 = failure code
+	        // TODO: replace assertion with logging and proper error handling
+	        ASSERT("ERROR");
+	      }
 
-      // combine high and low bytes
-      uint16_t conversionResultTotal = ( resultByteHigh & 0x0F ) + resultByteLow;
+	      // write 'recieve' command over i2c to dosimeter board, store return values
+	      // consecutive reads; first read is 'high' values, second is 'low' values
+	      uint8_t conversionResultByteHigh = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
+	      uint8_t conversionResultByteLow = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
 
-      // scale conversion result to final voltage value
-      float voltageResult = 3.30 * ( conversionResultTotal / 255.0 )
+	      // combine high and low values
+	      uint16_t conversionResultTotal = ( resultByteHigh & 0x0F ) + resultByteLow;
 
-      // store final voltage result in memory
-      storePayload( board, channel, voltageResult );
+	      // scale conversion result to final voltage value
+	      float voltageResult = DOSIMETER_REFERENCE_VOLTAGE * ( conversionResultTotal / 255.0 )
+
+	      // store final voltage result in memory
+	      storePayload( dosimeterBoard, adcChannel, voltageResult );
     }
   }
 }

--- a/payload-processing/payload_processing.c
+++ b/payload-processing/payload_processing.c
@@ -69,7 +69,9 @@ void requestReadingsAllChannels( void )
 		for ( uint8_t adcChannel = 0; adcChannel < 8; adcChannel++ ) {
 
 			// write command to dosimeter board using i2c
-			uint8_t i2cResult = i2c->writeByte( dosimeterBoardSlaveAddr[dosimeterBoard], dosimeterCommandBytes[adcChannel] );
+			uint8_t i2cResult = i2c->writeByte( dosimeterBoardSlaveAddr[dosimeterBoard],
+												dosimeterCommandBytes[adcChannel]
+											  	);
 
 			if ( i2cResult != 0 ) {
 				// 0 = success code; anything else is a failure

--- a/payload-processing/payload_processing.c
+++ b/payload-processing/payload_processing.c
@@ -73,11 +73,14 @@ void requestReadingsAllChannels( void )
 												dosimeterCommandBytes[adcChannel]
 											  	);
 
+			// check for success of I2C command
 			if ( i2cResult != 0 ) {
 				// 0 = success code; anything else is a failure
 				// TODO: replace assertion with logging and proper error handling
 				ASSERT("ERROR");
 			}
+
+			// TODO: Do we need to add any delays? Don't think so, but should confirm
 
 			// send the recieve command over i2c to dosimeter board; store return values
 			// high byte contains bits 11-8 (most signifigant), low contains bits 7-0

--- a/payload-processing/payload_processing.c
+++ b/payload-processing/payload_processing.c
@@ -80,8 +80,20 @@ void requestReadingsAllChannels( void )
 			// send the recieve command over i2c to dosimeter board; store return values
 			// high byte contains bits 11-8 (most signifigant), low contains bits 7-0
 			// TODO: modify in the future to work with real I2C commands
-			uint8_t conversionResultByteHigh = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
-			uint8_t conversionResultByteLow = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
+			uint8_t conversionResultHighByte = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
+			uint8_t conversionResultLowByte = i2c->readByte( dosimeterBoardSlaveAddr[dosimeterBoard] );
+
+			// check for zero values in response (values should never be zero)
+			if ( conversionResultHighByte == 0 ) {
+				// reading should never be 0
+				// TODO: replace assertion with logging and proper error handling
+				ASSERT("WARNING");
+			}
+			else if ( conversionResultLowByte == 0 ) {
+				// reading should never be 0
+				// TODO: replace assertion with logging and proper error handling
+				ASSERT("WARNING");
+			}
 
 			// combine high and low values
 			uint16_t conversionResultTotal = ( ( resultByteHigh & 0x0F ) << 8 ) + resultByteLow;

--- a/payload-processing/payload_processing.c
+++ b/payload-processing/payload_processing.c
@@ -1,0 +1,35 @@
+
+
+#include <housekeeping/i2c.h>
+#include <housekeeping/memory.h>
+
+// request a reading from one channel
+void requestReadingsAllChannels( void )
+{
+  for (int board = 0; board < 2; board++) {
+    // iterate through both boards
+
+    for (int channel = 0; channel < 8; channel++) {
+      // write command to dosimeter board using i2c
+      uint8_t result = i2c->writeByte(dosimeterBoardSlaveAddrsWrite[board], dosimeterCommandBytes[channel]);
+
+      if ( result ) {
+        // 0 = failure
+        ASSERT("ERROR");
+      }
+
+      // write recieve command over i2c to board
+      uint8_t conversionResultByteHigh = i2c->readByte(dosimeterBoardSlaveAddrsRead[board]);
+      uint8_t conversionResultByteLow = i2c->readByte(dosimeterBoardSlaveAddrsRead[board]);
+
+      // combine high and low bytes
+      uint16_t conversionResultTotal = ( resultByteHigh & 0x0F ) + resultByteLow;
+
+      // scale conversion result to final voltage value
+      float voltageResult = 3.30 * ( conversionResultTotal / 255.0 )
+
+      // store final voltage result in memory
+      storePayload( board, channel, voltageResult );
+    }
+  }
+}

--- a/payload-processing/payload_processing.h
+++ b/payload-processing/payload_processing.h
@@ -4,7 +4,19 @@
  */
 
 
-#define DOSIMETER_REFERENCE_VOLTAGE	(float) 3.30;
+//==============================================================================
+//                                    MACROS
+//==============================================================================
 
+/**
+ *	Reference voltage for the Melanin-Dosimeter boards. Sensors return relative
+ 	8-bit values. E.g. 127 out of 255 would be 50%, representing 1.65V
+ */
+#define DOSIMETER_REFERENCE_VOLTAGE	((float)3.30)
+
+
+//==============================================================================
+//                                FUNCTION STUBS
+//==============================================================================
 
 void requestReadingsAllChannels( void );

--- a/payload-processing/payload_processing.h
+++ b/payload-processing/payload_processing.h
@@ -1,0 +1,28 @@
+
+
+
+
+
+uint8_t dosimeterBoardSlaveAddrsWrite[2] = {
+  0x90,  // board one - 1001.0000
+  0x92   // board two - 1001.0010
+};
+
+uint8_t dosimeterBoardSlaveAddrsRead[2] = {
+  0x91,  // board one - 1001.0001
+  0x93   // board two - 1001.0011
+};
+
+uint8_t dosimeterCommandBytes[8] = {
+  0x84,     // 0 - 1000.0100
+  0xC4,     // 1 - 1100.0100
+  0x94,     // 2 - 1001.0100
+  0xD4,     // 3 - 1101.0100
+  0xA4,     // 4 - 1010.0100
+  0xE4,     // 5 - 1110.0100
+  0xB4,     // 6 - 1011.0100
+  0xF4      // 7 - 1111.0100
+};
+
+
+void requestReadingsAllChannels( void );

--- a/payload-processing/payload_processing.h
+++ b/payload-processing/payload_processing.h
@@ -1,28 +1,10 @@
+/*  payload_processing.h
+
+	Created by Tyrel Kostyk on February 11th 2020
+ */
 
 
-
-
-
-uint8_t dosimeterBoardSlaveAddrsWrite[2] = {
-  0x90,  // board one - 1001.0000
-  0x92   // board two - 1001.0010
-};
-
-uint8_t dosimeterBoardSlaveAddrsRead[2] = {
-  0x91,  // board one - 1001.0001
-  0x93   // board two - 1001.0011
-};
-
-uint8_t dosimeterCommandBytes[8] = {
-  0x84,     // 0 - 1000.0100
-  0xC4,     // 1 - 1100.0100
-  0x94,     // 2 - 1001.0100
-  0xD4,     // 3 - 1101.0100
-  0xA4,     // 4 - 1010.0100
-  0xE4,     // 5 - 1110.0100
-  0xB4,     // 6 - 1011.0100
-  0xF4      // 7 - 1111.0100
-};
+#define DOSIMETER_REFERENCE_VOLTAGE	(float) 3.30;
 
 
 void requestReadingsAllChannels( void );


### PR DESCRIPTION
Initial creation of payload processing functions. Contains but one function that rapidly polls and aquires data from each of the 8 sensors on both dosimeter boards. Relies on external functions from housekeeping team to send/recieve i2c commands/data, and to store payload data in memory.