### PR TITLE
Removed "Blocking" from the names of uartBlocking transmit and receive

### DIFF
--- a/radsat-sk/framework/wrappers/RUart.c
+++ b/radsat-sk/framework/wrappers/RUart.c
@@ -20,7 +20,7 @@ UARTconfig cameraConfig = {AT91C_US_USMODE_NORMAL | AT91C_US_CLKS_CLOCK | AT91C_
  * @param size: The number of bytes to be sent
  * @return An integer error code. 0 indicates success
  */
-uint32_t uartBlockingTransmit(const uint8_t* data, uint16_t size) {
+uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
 	return UART_write(bus0_uart, data, size);
 }
 

--- a/radsat-sk/framework/wrappers/RUart.c
+++ b/radsat-sk/framework/wrappers/RUart.c
@@ -21,7 +21,14 @@ UARTconfig cameraConfig = {AT91C_US_USMODE_NORMAL | AT91C_US_CLKS_CLOCK | AT91C_
  * @return An integer error code. 0 indicates success
  */
 uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
-	return UART_write(bus0_uart, data, size);
+	int err = UART_write(bus0_uart, data, size);
+	
+	if(err == 0) {
+		return err;
+	}
+	else {
+		return 1;
+	}
 }
 
 
@@ -32,7 +39,14 @@ uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
  * @return An integer error code. 0 indicates success
  */
 uint32_t uartReceive(uint8_t* data, uint16_t size) {
-	return UART_read(bus0_uart, data, size);
+	int err = UART_read(bus0_uart, data, size);
+	
+	if(err == 0) {
+		return err;
+	}
+	else {
+		return 1;
+	}
 }
 
 /**

--- a/radsat-sk/framework/wrappers/RUart.c
+++ b/radsat-sk/framework/wrappers/RUart.c
@@ -31,7 +31,7 @@ uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
  * @param size: The number of bytes to receive over UART
  * @return An integer error code. 0 indicates success
  */
-uint32_t uartBlockingReceive(uint8_t* data, uint16_t size) {
+uint32_t uartReceive(uint8_t* data, uint16_t size) {
 	return UART_read(bus0_uart, data, size);
 }
 

--- a/radsat-sk/framework/wrappers/RUart.h
+++ b/radsat-sk/framework/wrappers/RUart.h
@@ -17,7 +17,7 @@
                                              FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-uint32_t uartBlockingTransmit(const uint8_t* data, uint16_t size);
+uint32_t uartTransmit(const uint8_t* data, uint16_t size);
 uint32_t uartBlockingReceive(uint8_t* data, uint16_t size);
 uint32_t uartInit();
 

--- a/radsat-sk/framework/wrappers/RUart.h
+++ b/radsat-sk/framework/wrappers/RUart.h
@@ -18,7 +18,7 @@
 ***************************************************************************************************/
 
 uint32_t uartTransmit(const uint8_t* data, uint16_t size);
-uint32_t uartBlockingReceive(uint8_t* data, uint16_t size);
+uint32_t uartReceive(uint8_t* data, uint16_t size);
 uint32_t uartInit();
 
 #endif /* RUART_H_ */


### PR DESCRIPTION
These were two separate hotfixes, but it seemed natural to put them in the same PR.