### PR TITLE
Included Satellite Subsystem Interface library within the Eclipse project settings

### DIFF
--- a/radsat-sk/.cproject
+++ b/radsat-sk/.cproject
@@ -88,6 +88,7 @@
 									<listOptionValue builtIn="false" value="../src/tasks"/>
 									<listOptionValue builtIn="false" value="../operation/crypt/tiny-aes"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/satellite-subsystems/satellite-subsystems/include&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.663972223" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="sdram"/>
@@ -113,12 +114,14 @@
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/freertos/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hal/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/lib&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/satellite-subsystems/satellite-subsystems/lib&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs.2052718930" name="Libraries (-l)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs" valueType="libs">
 									<listOptionValue builtIn="false" value="HALD"/>
 									<listOptionValue builtIn="false" value="FreeRTOSD"/>
 									<listOptionValue builtIn="false" value="At91D"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="HCCD"/>
+									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="SatelliteSubsystemsD"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker.input.1144742114" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
@@ -230,6 +233,7 @@
 									<listOptionValue builtIn="false" value="../src/tasks"/>
 									<listOptionValue builtIn="false" value="../operation/crypt/tiny-aes"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/satellite-subsystems/satellite-subsystems/include&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.774467720" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="TRACE_LEVEL=5"/>
@@ -254,12 +258,15 @@
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/freertos/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hal/lib&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/lib&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/satellite-subsystems/satellite-subsystems/lib&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs.1980502589" name="Libraries (-l)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs" valueType="libs">
 									<listOptionValue builtIn="false" value="HAL"/>
 									<listOptionValue builtIn="false" value="FreeRTOS"/>
 									<listOptionValue builtIn="false" value="At91"/>
 									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="HCC"/>
+									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="libSatelliteSubsystemsD"/>
+									<listOptionValue builtIn="false" srcPrefixMapping="" srcRootPath="" value="SatelliteSubsystemsD"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker.input.1145212187" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>


### PR DESCRIPTION
Updated the project settings to include the ISISpace SSI Library. Note that the library itself will never be on GitHub (as stated in the `.gitignore`), so they have to be manually downloaded.

Before approving this PR, please follow the instructions in the DropBox Training Doc (found [here](https://www.dropbox.com/home/CubeSat/Subteams/Software%20and%20Command/Learning/Training?preview=CCP-SOFT-13-0184B-Software_Team_Training_Document.pdf)), in Section 4.5.3. After downloading the proper folder, checkout this branch, and compile the code to ensure it works. To confirm that the library is being referenced properly, add the following lines:
1. `#include <satellite-subsystems/IsisTRXVU.h>` Add this near the top, to include the correct header file
2. `int res = IsisTrxvu_tcClearBeacon((unsigned char)8);` Add this in the middle of `main()` to access the library

Again, confirm that it compiles without warning. THEN you can approve the PR. Thanks :)


