### PR TITLE
Updated return codes for FRAM, I2C, and UART wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ To increase readability (especially in larger files), multi-line function separa
 ***************************************************************************************************/
 ```
 Each line ends after exactly 100 characters, and the words are centered.
-These are not strictly enforced, but are recommended. Consistency is the most important thing.
+These are not strictly enforced, but are highly recommended. Consistency is the most important thing.
 
 ### Whitespace
 #### Around Brackets

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Code and Documentation for USST’s first Canadian CubeSat Project: The RADSAT-S
     6. [Parentheses in Expressions](#Parentheses-in-Expressions)
     7. [Switch Statements](#Switch-Statements)
     8. [Line Lengths](#Line-Lengths)
+    9. [Error Codes](#Error-Codes)
 6. [Code Documentation](#Code-Documentation)
     1. [Functions](#Functions)
     2. [Global Variables](#Global-Variables)
@@ -331,6 +332,26 @@ uint16_t function(uint16_t n) {
 ### Line Lengths
 Lines should aim to be 80 characters or less long, but the maximum accepted line length will be roughly 100 since no one really uses terminals anyways. Some exceptions may be made, but anything over 100 lines is starting to push the limits of readability.
 
+### Error Codes
+Functions that wish to return an "error code" (e.g. a value that represents if the function was successful in its operation) should follow the following format:
+Return type: int
+Return value: 0 for success, non-zero for failure. Reference the HAL, SSI, or other underlying files for more info if the error code does not originate in the function you're describing. An example is shown below:
+``` c
+/**
+ * @brief Write data into the FRAM peripheral.
+ * @param data The pointer to where the data will be copied from.
+ * @param address The FRAM address to begin writing data to.
+ * @param size The number of bytes to copy into the FRAM peripheral.
+ * @return 0 for success, non-zero for failure. See hal/Storage/FRAM.h for details.
+ */
+int framWrite(uint8_t* data, uint32_t address, uint32_t size) {
+
+	int error = FRAM_writeAndVerify(data, address, size);
+	return error;
+}
+```
+Note that for functions which use their return values for other purposes (e.g. returning a calculated value) or simply return `void`, this section can be ignored.
+
 
 ## Code Documentation
 Our code is documented using [doxygen](http://www.doxygen.nl/). All comments
@@ -352,13 +373,30 @@ the function is defined in.
  * @note give a notice to anyone using this function (if any; usually not)
  * @pre describe the pre condition (if any; usually not)
  * @post describe the post condition (if any; usually not)
- * @param c short description of the parameter
+ * @param input short description of the input parameter
  * @return describe the return value
  */
-uint32_t function (uint8_t c) {
+int function (uint8_t input) {
     // code
 }
 ```
+
+Another real example is shown below:
+``` c
+/**
+ * @brief Write data into the FRAM peripheral.
+ * @param data The pointer to where the data will be copied from.
+ * @param address The FRAM address to begin writing data to.
+ * @param size The number of bytes to copy into the FRAM peripheral.
+ * @return 0 for success, non-zero for failure. See hal/Storage/FRAM.h for details.
+ */
+int framWrite(uint8_t* data, uint32_t address, uint32_t size) {
+
+	int error = FRAM_writeAndVerify(data, address, size);
+	return error;
+}
+```
+
 
 ### Global Variables
 Documentation for global variables should go inside the source (.c) file that they are defined in.

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ the function is defined in.
  * @param input short description of the input parameter
  * @return describe the return value
  */
-int function (uint8_t input) {
+int function(uint8_t input) {
     // code
 }
 ```

--- a/README.md
+++ b/README.md
@@ -155,12 +155,17 @@ ALso note that the enumeration values are all explictly defined; this is highly 
 In functions, most variables that will be used throughout the function should be declared at the *top* of the function. Exceptions may include variable declarations within the scope of an if or for loop.
 
 #### Types
-Use of "non-standard" c types (char, int, long) should be avoided whenever possible. In embedded programming, it is always recommended to use explicit types. It's clearer to the user/reader, and consistent across all platforms. However, signed types do have their uses; e.g. the HAL and SSI libraries use `int` for return types (error codes), so it's fine to use them when working directly with those libraries. Standard c types include:
+Use of "non-standard" c types (`char`, `int`, `long`) should be avoided whenever possible. In embedded programming, it is always recommended to use explicit types. It's clearer to the user/reader, and consistent across all platforms. However, signed types do have their uses; e.g. the HAL and SSI libraries use `int` for return types (error codes), so it's fine to use them when working directly with those libraries.
+
+Standard c types (also called fixed-width types, or explicit types) include:
 - `uint8_t` (instead of `unsigned short` or `unsigned char`)
 - `uint16_t` (instead of `unsigned int`)
 - `uint32_t` (instead of `unsigned long`)
-^ remove the "u" prefix to use a signed version of the type when necessary.
-We only have 1 system to worry about with our project (the OBC), so portability isn't a _huge_ concern, but it's still good practice to use explicit types whenever reasonable and possible.
+
+Remove the "u" prefix to use a signed version of the above types when signed values are needed.
+
+We only have 1 system to worry about with our project (the OBC), so portability isn't a _huge_ concern, but it's still good practice to use explicit types whenever reasonable and possible. IF YOU'RE UNSURE OF WHAT TO USE: just use fixed-width (standard) c types, as listed above.
+
 
 ### Files
 #### File Naming
@@ -377,7 +382,7 @@ the function is defined in.
  * @param input short description of the input parameter
  * @return describe the return value
  */
-int function(uint8_t input) {
+uint16_t function(uint8_t input) {
     // code
 }
 ```

--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ ALso note that the enumeration values are all explictly defined; this is highly 
 In functions, most variables that will be used throughout the function should be declared at the *top* of the function. Exceptions may include variable declarations within the scope of an if or for loop.
 
 #### Types
-Use of non-standard c types (char, int, long) should be avoided whenever possible. In embedded programming, it is always recommended to use explicit types. It's clearer to the user/reader, and consistent across all platforms. Unsigned types should always be used unless signedness is needed (should rarely be the case). Standard c types include:
-- uint8_t (instead of unsigned short or unsigned char)
-- uint16_t (instead of unsigned short)
-- uint32_t (instead of unsigned long)
-^ removed the "u" to use a signed version of the type when necessary.
+Use of "non-standard" c types (char, int, long) should be avoided whenever possible. In embedded programming, it is always recommended to use explicit types. It's clearer to the user/reader, and consistent across all platforms. However, signed types do have their uses; e.g. the HAL and SSI libraries use `int` for return types (error codes), so it's fine to use them when working directly with those libraries. Standard c types include:
+- `uint8_t` (instead of `unsigned short` or `unsigned char`)
+- `uint16_t` (instead of `unsigned int`)
+- `uint32_t` (instead of `unsigned long`)
+^ remove the "u" prefix to use a signed version of the type when necessary.
+We only have 1 system to worry about with our project (the OBC), so portability isn't a _huge_ concern, but it's still good practice to use explicit types whenever reasonable and possible.
 
 ### Files
 #### File Naming

--- a/radsat-sk/framework/fileio/RFram.c
+++ b/radsat-sk/framework/fileio/RFram.c
@@ -15,16 +15,12 @@
 
 /**
  * @brief Initialize the FRAM peripheral driver.
- * @return 0 for success, 1 for failure.
+ * @return 0 for success, non-zero for failure. See hal/Storage/FRAM.h for details.
  */
-uint16_t framInit(void) {
-	int16_t err = FRAM_start();
+int framInit(void) {
 
-	if (err != 0) {
-		return 1;
-	}
-
-	return 0;
+	int error = FRAM_start();
+	return error;
 }
 
 
@@ -33,17 +29,12 @@ uint16_t framInit(void) {
  * @param data The pointer to where the extracted data will be copied.
  * @param address The FRAM address to begin extracting data from.
  * @param size The number of bytes to copy out of the FRAM peripheral.
- * @return 0 for success, 1 for failure. See hal/Storage/FRAM.h for more details.
+ * @return 0 for success, non-zero for failure. See hal/Storage/FRAM.h for details.
  */
-uint16_t framRead(uint8_t* data, uint32_t address, uint32_t size) {
+int framRead(uint8_t* data, uint32_t address, uint32_t size) {
 
-	int16_t err = FRAM_read(data, address, size);
-
-	if (err != 0) {
-		return 1;
-	}
-
-	return 0;
+	int error = FRAM_read(data, address, size);
+	return error;
 }
 
 
@@ -52,16 +43,10 @@ uint16_t framRead(uint8_t* data, uint32_t address, uint32_t size) {
  * @param data The pointer to where the data will be copied from.
  * @param address The FRAM address to begin writing data to.
  * @param size The number of bytes to copy into the FRAM peripheral.
- * @return 0 for success, 1 for failure. See hal/Storage/FRAM.h for more details.
+ * @return 0 for success, non-zero for failure. See hal/Storage/FRAM.h for details.
  */
-uint16_t framWrite(uint8_t* data, uint32_t address, uint32_t size) {
+int framWrite(uint8_t* data, uint32_t address, uint32_t size) {
 
-	int16_t err = FRAM_writeAndVerify(data, address, size);
-
-	if (err != 0) {
-		return 1;
-	}
-
-	return 0;
-
+	int error = FRAM_writeAndVerify(data, address, size);
+	return error;
 }

--- a/radsat-sk/framework/fileio/RFram.h
+++ b/radsat-sk/framework/fileio/RFram.h
@@ -14,9 +14,9 @@
                                              PUBLIC API
 ***************************************************************************************************/
 
-uint16_t framInit(void);
-uint16_t framRead(uint8_t* data, uint32_t address, uint32_t size);
-uint16_t framWrite(uint8_t* data, uint32_t address, uint32_t size);
+int framInit(void);
+int framRead(uint8_t* data, uint32_t address, uint32_t size);
+int framWrite(uint8_t* data, uint32_t address, uint32_t size);
 
 
 #endif /* RFRAM_H_ */

--- a/radsat-sk/framework/wrappers/RI2C.c
+++ b/radsat-sk/framework/wrappers/RI2C.c
@@ -13,22 +13,17 @@
                                              PUBLIC API
 ***************************************************************************************************/
 
-
 /**
  * Initializes the I2C driver
  *
- * @return 0 for success, otherwise review I2C.h for return definition
+ * @return 0 for success, non-zero for failure. See hal/Drivers/I2C.h for details.
  */
-uint32_t i2cInit() {
+int i2cInit(void) {
 
-	uint16_t err = I2C_start(I2C_BUSSPEED_HZ, I2C_TRANSFERTIMEOUT);
-
-	if (err != 0) {
-		return err;
-	}
-
-	return 0;
+	int error = I2C_start(I2C_BUSSPEED_HZ, I2C_TRANSFERTIMEOUT);
+	return error;
 }
+
 
 /**
  * Writes data to a slave
@@ -38,18 +33,14 @@ uint32_t i2cInit() {
  * @param slaveAddress address of the slave where to make the transfer
  * @param data Memory location of the data to be written
  * @param size Number of bytes to be written to the I2C slave
- * @return 0 for success, otherwise review I2C.h for return definition
+ * @return 0 for success, non-zero for failure. See hal/Drivers/I2C.h for details.
  */
-uint32_t i2cTransmit(uint16_t slaveAddress, const uint8_t* data, uint16_t size) {
+int i2cTransmit(uint16_t slaveAddress, const uint8_t* data, uint16_t size) {
 
-	uint16_t err = I2C_write(slaveAddress, data, size);
-
-	if (err != 0) {
-		return err;
-	}
-
-	return 0;
+	int error = I2C_write(slaveAddress, data, size);
+	return error;
 }
+
 
 /**
  * Reads data from a slave
@@ -59,18 +50,14 @@ uint32_t i2cTransmit(uint16_t slaveAddress, const uint8_t* data, uint16_t size) 
  * @param slaveAddress Address of the slave where to make the transfer.
  * @param data Memory location to store the data read from the I2C slave. Must be able to store size bytes.
  * @param size Number of bytes to be read from the I2C slave.
- * @return 0 for success, otherwise review I2C.h for return definition
+ * @return 0 for success, non-zero for failure. See hal/Drivers/I2C.h for details.
  */
-uint32_t i2cRecieve(uint16_t slaveAddress, uint8_t* data, uint16_t size) {
+int i2cRecieve(uint16_t slaveAddress, uint8_t* data, uint16_t size) {
 
-	uint16_t err = I2C_read(slaveAddress, data, size);
-
-	if (err != 0) {
-		return err;
-	}
-
-	return 0;
+	int error = I2C_read(slaveAddress, data, size);
+	return error;
 }
+
 
 /**
  * Queues a transfer into the I2C driver
@@ -82,10 +69,10 @@ uint32_t i2cRecieve(uint16_t slaveAddress, uint8_t* data, uint16_t size) {
  * @param readSize Number of bytes to be read from the I2C slave
  * @param writeData Memory location of the data to be written to the I2C slave
  * @param readData Memory location to store the data read from the I2C slave
- * @return 0 for success, otherwise review I2C.h for return definition
+ * @return 0 for success, non-zero for failure. See hal/Drivers/I2C.h for details.
  *
  */
-uint32_t i2cQueue(uint16_t slaveAddress, uint16_t writeSize, uint16_t readSize, uint8_t* writeData, volatile uint8_t* readData) {
+int i2cQueue(uint16_t slaveAddress, uint16_t writeSize, uint16_t readSize, uint8_t* writeData, volatile uint8_t* readData) {
 
 	struct _I2CgenericTransfer master;
 	master.slaveAddress = slaveAddress;
@@ -98,16 +85,6 @@ uint32_t i2cQueue(uint16_t slaveAddress, uint16_t writeSize, uint16_t readSize, 
 	uint16_t status = I2C_getCurrentTransferStatus();
 	master.result = status;
 
-	uint16_t err = I2C_queueTransfer(&master);
-
-	if (err != 0) {
-		return err;
-	}
-
-	return 0;
-
+	int error = I2C_queueTransfer(&master);
+	return error;
 }
-
-
-
-

--- a/radsat-sk/framework/wrappers/RI2C.h
+++ b/radsat-sk/framework/wrappers/RI2C.h
@@ -32,11 +32,10 @@
                                              FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-
-uint32_t i2cInit();
-uint32_t i2cTransmit(uint16_t slaveAddress, const uint8_t* data, uint16_t size);
-uint32_t i2cRecieve(uint16_t slaveAddress, uint8_t* data, uint16_t size);
-uint32_t i2cQueue(uint16_t slaveAddress, uint16_t writeSize, uint16_t readSize, uint8_t* writeData, volatile uint8_t* readData);
+int i2cInit(void);
+int i2cTransmit(uint16_t slaveAddress, const uint8_t* data, uint16_t size);
+int i2cRecieve(uint16_t slaveAddress, uint8_t* data, uint16_t size);
+int i2cQueue(uint16_t slaveAddress, uint16_t writeSize, uint16_t readSize, uint8_t* writeData, volatile uint8_t* readData);
 
 
 #endif /* RI2C_H_ */

--- a/radsat-sk/framework/wrappers/RUart.c
+++ b/radsat-sk/framework/wrappers/RUart.c
@@ -11,24 +11,20 @@
                                              PUBLIC API
 ***************************************************************************************************/
 
-UARTconfig cameraConfig = {AT91C_US_USMODE_NORMAL | AT91C_US_CLKS_CLOCK | AT91C_US_CHRL_8_BITS | AT91C_US_PAR_NONE | AT91C_US_OVER_16 | AT91C_US_NBSTOP_1_BIT,
-		CAMERA_BAUD_RATE, TIME_GUARD, rs232_uart, RX_TIMEOUT};
+UARTconfig cameraConfig = {AT91C_US_USMODE_NORMAL | AT91C_US_CLKS_CLOCK | AT91C_US_CHRL_8_BITS |
+						   AT91C_US_PAR_NONE | AT91C_US_OVER_16 | AT91C_US_NBSTOP_1_BIT,
+						   CAMERA_BAUD_RATE, TIME_GUARD, rs232_uart, RX_TIMEOUT};
 
 /**
  * Sends the given data over UART
  * @param data: A pointer to the data to send over UART
  * @param size: The number of bytes to be sent
- * @return An integer error code. 0 indicates success
+ * @return 0 for success, non-zero for failure. See hal/Drivers/UART.h for details.
  */
-uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
-	int err = UART_write(bus0_uart, data, size);
-	
-	if(err == 0) {
-		return err;
-	}
-	else {
-		return 1;
-	}
+int uartTransmit(const uint8_t* data, uint16_t size) {
+
+	int error = UART_write(bus0_uart, data, size);
+	return error;
 }
 
 
@@ -36,27 +32,24 @@ uint32_t uartTransmit(const uint8_t* data, uint16_t size) {
  * Receives data over UART and stores it in the given buffer
  * @param data: A buffer to store the received data in
  * @param size: The number of bytes to receive over UART
- * @return An integer error code. 0 indicates success
+ * @return 0 for success, non-zero for failure. See hal/Drivers/UART.h for details.
  */
-uint32_t uartReceive(uint8_t* data, uint16_t size) {
-	int err = UART_read(bus0_uart, data, size);
-	
-	if(err == 0) {
-		return err;
-	}
-	else {
-		return 1;
-	}
+int uartReceive(uint8_t* data, uint16_t size) {
+
+	int error = UART_read(bus0_uart, data, size);
+	return error;
 }
+
 
 /**
  * Initializes UART and enables receiving on the bus
- * @return An integer error code. 0 indicates success
+ * @return 0 for success, non-zero for failure. See hal/Drivers/UART.h for details.
  */
-uint32_t uartInit() {
-	int err = UART_start(bus0_uart, cameraConfig);
-	if(err != 0) {
-		return err;
+int uartInit(void) {
+
+	int error = UART_start(bus0_uart, cameraConfig);
+	if (error != 0) {
+		return error;
 	}
 	return UART_setRxEnabled(bus0_uart, TRUE);
 }

--- a/radsat-sk/framework/wrappers/RUart.h
+++ b/radsat-sk/framework/wrappers/RUart.h
@@ -17,8 +17,8 @@
                                              FUNCTION DECLARATIONS
 ***************************************************************************************************/
 
-uint32_t uartTransmit(const uint8_t* data, uint16_t size);
-uint32_t uartReceive(uint8_t* data, uint16_t size);
-uint32_t uartInit();
+int uartTransmit(const uint8_t* data, uint16_t size);
+int uartReceive(uint8_t* data, uint16_t size);
+int uartInit(void);
 
 #endif /* RUART_H_ */


### PR DESCRIPTION
See issue #132 for more information.

Mostly just standardized the return types; they simply pass along the same style of error code that the HAL and SSI use. Addi and I figured that consistency with the HAL and SSI were more important than using fixed-width integers