### PR TITLE
Added the printDebug function in the new RDebug module

### DIFF
--- a/radsat-sk/.cproject
+++ b/radsat-sk/.cproject
@@ -84,6 +84,7 @@
 									<listOptionValue builtIn="false" value="../operation/message/protobuf/types"/>
 									<listOptionValue builtIn="false" value="../operation/message/protobuf/nanopb"/>
 									<listOptionValue builtIn="false" value="../operation/subsystems"/>
+									<listOptionValue builtIn="false" value="../operation/utility"/>
 									<listOptionValue builtIn="false" value="../src/tasks"/>
 									<listOptionValue builtIn="false" value="../operation/crypt/tiny-aes"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/include&quot;"/>
@@ -98,7 +99,7 @@
 									<listOptionValue builtIn="false" value="'BASE_REVISION_HASH_SHORT=$(REVHASH_SHORT)'"/>
 									<listOptionValue builtIn="false" value="'BASE_REVISION_HASH=$(REVHASH)'"/>
 								</option>
-								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.534234401" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std" value="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.gnu99" valueType="enumerated"/>
+								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.534234401" name="Language standard" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std" useByScannerDiscovery="true" value="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.std.gnu99" valueType="enumerated"/>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.821686405" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>
 							<tool id="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.413877822" name="Cross ARM C++ Compiler" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler"/>
@@ -229,6 +230,7 @@
 									<listOptionValue builtIn="false" value="../operation/message/protobuf/types"/>
 									<listOptionValue builtIn="false" value="../operation/message/protobuf/nanopb"/>
 									<listOptionValue builtIn="false" value="../operation/subsystems"/>
+									<listOptionValue builtIn="false" value="../operation/utility"/>
 									<listOptionValue builtIn="false" value="../src/tasks"/>
 									<listOptionValue builtIn="false" value="../operation/crypt/tiny-aes"/>
 									<listOptionValue builtIn="false" value="&quot;${external-dependencies}/hal/hcc/include&quot;"/>

--- a/radsat-sk/framework/serial/RI2c.c
+++ b/radsat-sk/framework/serial/RI2c.c
@@ -36,9 +36,9 @@ static int initialized = 0;
  */
 int i2cInit(void) {
 
-	// only allow initialization once
+	// only allow initialization once (exit gracefully)
 	if (initialized)
-		return E_IS_INITIALIZED;
+		return 0;
 
 	int error = I2C_start(I2C_BUS_SPEED_HZ, I2C_TRANSFER_TIMEOUT);
 

--- a/radsat-sk/framework/serial/RUart.c
+++ b/radsat-sk/framework/serial/RUart.c
@@ -48,15 +48,15 @@ static int initialized[UART_BUS_COUNT] = {0};
  */
 int uartInit(UARTbus bus) {
 
-	// only allow initialization once
-	if (initialized[bus] != 0)
-		return E_IS_INITIALIZED;
+	// only allow initialization once (exit gracefully)
+	if (initialized[bus])
+		return 0;
 
 	// select appropriate pre-made configuration
 	UARTconfig config = {0};
-	if (bus == CAMERA_UART_BUS)
+	if (bus == UART_CAMERA_BUS)
 		config = cameraConfig;
-	else if (bus == DEBUG_UART_BUS)
+	else if (bus == UART_DEBUG_BUS)
 		config = debugConfig;
 	else
 		return -1;

--- a/radsat-sk/framework/serial/RUart.h
+++ b/radsat-sk/framework/serial/RUart.h
@@ -15,8 +15,8 @@
                                             DEFINITIONS
 ***************************************************************************************************/
 
-#define CAMERA_UART_BUS		((UARTbus) bus0_uart)
-#define DEBUG_UART_BUS		((UARTbus) bus2_uart)
+#define UART_CAMERA_BUS		((UARTbus) bus0_uart)
+#define UART_DEBUG_BUS		((UARTbus) bus2_uart)
 
 
 /***************************************************************************************************

--- a/radsat-sk/operation/utility/RDebug.c
+++ b/radsat-sk/operation/utility/RDebug.c
@@ -1,0 +1,44 @@
+/**
+ * @file RDebug.c
+ * @date December 29, 2021
+ * @author Tyrel Kostyk
+ */
+
+#include <RDebug.h>
+#include <RUart.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+
+/***************************************************************************************************
+                                            DEFINITIONS
+***************************************************************************************************/
+
+#define MAX_DEBUG_CHAR_LENGTH	(4096)
+
+
+/***************************************************************************************************
+                                             PUBLIC API
+***************************************************************************************************/
+
+void debugPrint(const char* stringFormat, ...) {
+#ifdef DEBUG
+
+	// initialize the variadic argument list
+	va_list arguments;
+	va_start(arguments, stringFormat);
+
+	// buffer to hold the final string after formatting
+	char buffer[MAX_DEBUG_CHAR_LENGTH] = { 0 };
+
+	// format the string, store it in the internal buffer (add 1 for the string terminating byte)
+	int length = vsnprintf(buffer, MAX_DEBUG_CHAR_LENGTH, stringFormat, arguments) + 1;
+
+	// done with the variadic arguments
+	va_end(arguments);
+
+	// transmit the UART message across the debug (secondary) serial port
+	uartTransmit(UART_DEBUG_BUS, (const uint8_t *)buffer, length);
+
+#endif /* DEBUG */
+}

--- a/radsat-sk/operation/utility/RDebug.h
+++ b/radsat-sk/operation/utility/RDebug.h
@@ -1,0 +1,20 @@
+/**
+ * @file RDebug.h
+ * @date December 29, 2021
+ * @author Tyrel Kostyk
+ */
+
+#ifndef RDEBUG_H_
+#define RDEBUG_H_
+
+#include <stdint.h>
+
+
+/***************************************************************************************************
+                                             PUBLIC API
+***************************************************************************************************/
+
+void debugPrint(const char* stringFormat, ...);
+
+
+#endif /* RDEBUG_H_ */


### PR DESCRIPTION
Added a Debug module with a single public function. Pretty simple, allows programmers to add a `debugPrint("The result is %d", myVar);` and it will transmit that message over the UART debug port (which can be easily hooked up to a computer USB port and printed to a terminal). Aka, it works the same as `printf` once everything is set up.

To test this (without hardware) you can pretty much only make sure it compiles. Could also try using it in main.c or something, that should work fine as well.

Issue #145 