### PR TITLE
Operation/end to end camera controls

### DIFF
--- a/radsat-sk/operation/services/RCameraService.c
+++ b/radsat-sk/operation/services/RCameraService.c
@@ -98,7 +98,12 @@ int requestReset(uint8_t resetOption) {
 	if (resetOption < 1 || resetOption > 3)
 		return E_GENERIC;
 
-	return executeReset(resetOption);
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	int error = executeReset(resetOption);
+	cubeSenseIsInUse = 0;
+	return error;
 }
 
 
@@ -333,7 +338,12 @@ uint8_t getImageDownloadSize(void) {
  * @return error, 0 on success, otherwise failure
  */
 int requestImageCapture(uint8_t camera, uint8_t sram, uint8_t location) {
-	return captureImage(camera, sram, location);
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	int error = captureImage(camera, sram, location);
+	cubeSenseIsInUse = 0;
+	return error;
 }
 
 

--- a/radsat-sk/operation/services/RCameraService.c
+++ b/radsat-sk/operation/services/RCameraService.c
@@ -1,0 +1,622 @@
+/**
+ * @file RCameraService.c
+ * @date September 28, 2022
+ * @author
+ */
+
+#include <RCameraService.h>
+#include <RCameraCommon.h>
+#include <RCamera.h>
+#include <RCommon.h>
+#include <stdlib.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <math.h>
+
+/***************************************************************************************************
+                                   DEFINITIONS & PRIVATE GLOBALS
+***************************************************************************************************/
+
+/* Number of attempts for image capture with successful detection results */
+#define VALID_IMAGE_RETRY_COUNT			(10)
+
+/* Delay in milliseconds to allow image capture to be completed */
+#define IMAGE_CAPTURE_DELAY_MS			(1000)
+
+/** Maximum value of the current frame index, used as the default initial value. **/
+#define MAX_FRAME_INDEX					(65535)
+
+/** Stack size (in bytes) allotted to the image download FreeRTOS Task. */
+#define DOWNLOAD_TASK_STACK_SIZE		(configMINIMAL_STACK_SIZE + 50)
+
+/** Current camera settings and initialization flag. **/
+static CameraSettings cameraSettings = { 0 };
+//static uint8_t cameraSettingsInitialized = 0;
+
+/** Interval (in ms) for the automatic image capture. **/
+int imageCaptureInterval = 0;
+
+/** Size used for image download during automatic image capture **/
+/** 0 = 1024x1024, 1 = 512x512, 2 = 256x256, 3 = 128x128, 4 = 64x64 **/
+uint8_t imageDownloadSize = 4;
+
+/** Pointer to a local image frames prepared for downlink. */
+static full_image_t *image;
+/** Flag indicating image is ready for downlink. **/
+static uint8_t imageReadyForDownlink = 0;
+/** Flag indicating system ready for a new image capture. **/
+static uint8_t imageReadyForNewCapture = 1;
+
+/** Index of the current image frame prepared for downlink. */
+static uint16_t currentImageFrameIndex = MAX_FRAME_INDEX;
+
+/** Flag indicating that the CubeSense is currently in use. Used to prevent conflicts. **/
+static uint8_t cubeSenseIsInUse = 0;
+
+/** FreeRTOS Task Handles. */
+static xTaskHandle imageDownloadTaskHandle;
+
+/** Image Download Task Priority. Periodically download image frames; medium priority task. */
+static const int imageDownloadTaskPriority = configMAX_PRIORITIES - 3;
+
+/* Struct for image download parameters and local variable */
+typedef struct _image_download_t {
+	uint8_t sram;
+	uint8_t size;
+} image_download_t;
+static image_download_t downloadParameters = {0};
+
+/* Struct for ADCS burst measurement parameters and local variable */
+typedef struct _adcs_capture_settings_t {
+	uint8_t nbMeasurements;
+	int interval;
+} adcs_capture_settings_t;
+static adcs_capture_settings_t adcsSettings = {0};
+
+/** Pointer to a local ADCS measurements results prepared for downlink. */
+static adcs_detection_results_t *adcsResults;
+/** Flag indicating ADCS is ready for a new burst (1=ready, 0=not ready). **/
+static uint8_t adcsReadyForNewBurst = 1;
+
+/***************************************************************************************************
+                                       PRIVATE FUNCTION STUBS
+***************************************************************************************************/
+
+void ImageDownloadTask(void* parameters);
+
+/***************************************************************************************************
+                                             PUBLIC API
+***************************************************************************************************/
+
+/*
+ * Trigger a CubeSense reset.
+ *
+ * @param resetOption defines the system to reset, 1 = reset communication, 2 = reset cameras, 3 = reset MCU
+ * @return 0 on success, otherwise failure
+ */
+int requestReset(uint8_t resetOption) {
+	// Check for invalid reset option
+	if (resetOption < 1 || resetOption > 3)
+		return E_GENERIC;
+
+	return executeReset(resetOption);
+}
+
+
+/*
+ * Set settings for both CubeSense cameras.
+ *
+ * @param newSettings defines the cameras settings to set
+ * @return error, 0 for success, otherwise failure
+ */
+int setCamerasSettings(CameraSettings newSettings) {
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	int error;
+
+	// TODO: Do we need this or not? Is the FULL struct sent via telecommand?
+	/*if (!cameraSettingsInitialized) {
+		printf("Getting camera settings...\n");
+		error = getSettings(&cameraSettings);
+		if (error != SUCCESS) {
+			printf("Failed to get camera settings...\n");
+			// TODO
+			cubeSenseIsInUse = 0;
+			return E_GENERIC;
+		}
+		printf("Exposure = %i\n", cameraSettings.cameraTwoSettings.exposure);
+		printf("Detection Threshold = %i\n", cameraSettings.cameraTwoSettings.detectionThreshold);
+		cameraSettingsInitialized = 1;
+	}*/
+
+	cameraSettings = newSettings;
+
+	// TODO: TO DELETE
+	//cameraSettings.cameraTwoSettings.exposure = 10000;
+	//cameraSettings.cameraTwoSettings.detectionThreshold = 150;
+
+	error = setSettings(&cameraSettings);
+	cubeSenseIsInUse = 0;
+	if (error != SUCCESS) {
+		printf("Failed to update camera settings...\n");
+		// TODO
+		return E_GENERIC;
+	}
+
+	return SUCCESS;
+}
+
+
+/*
+ * Set the capture settings used for ADCS measurement, which
+ * will execute a burst of measurements.
+ *
+ * @param nbMeasurements defines the number of measurements in the burst
+ * @param interval defines the interval (in ms) between measurements
+ */
+void setADCSCaptureSettings(uint8_t nbMeasurements, int interval) {
+	adcsSettings.nbMeasurements = nbMeasurements;
+	adcsSettings.interval = interval;
+}
+
+
+/*
+ * Take a burst of measurements for ADCS and
+ * store the results in a static variable.
+ *
+ * @return error, 0 for success, otherwise failure
+ */
+int takeADCSBurstMeasurements(void) {
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	int error;
+
+	// Free allocated memory of struct
+	free(adcsResults);
+
+	// Allocate memory to struct to store measurements
+	adcsResults = initializeNewADCSResults(adcsSettings.nbMeasurements);
+
+	// Run a first image capture & detect so the first results can be read
+	error = triggerNewDetectionForBothSensors();
+	if (error != SUCCESS) {
+		printf("Failed to trigger a first capture and detect...\n");
+	}
+
+	// Wait for first captures to be done
+	vTaskDelay(adcsSettings.interval);
+
+	// Iterate to get the detection results
+	uint8_t resultIndex = 0;
+	printf("Number of measurements = %d\n", adcsSettings.nbMeasurements);
+	for (int i = 0; i < adcsSettings.nbMeasurements; i++) {
+		printf("Detection measurement #%d\n", i);
+		// Get detection results and trigger a new detection
+		detection_results_t detectionResult = {0};
+		error = getResultsAndTriggerNewDetection(&detectionResult);
+		if (error == SUCCESS) {
+			// Store the successful result
+			adcsResults->results[resultIndex] = detectionResult;
+			resultIndex++;
+		}
+
+		// Wait before the next measurement
+		vTaskDelay(adcsSettings.interval);
+	}
+	// Store the number of valid measurements
+	adcsResults->validMeasurementsCount = resultIndex;
+
+	// Set the ADCS readiness flag so no new burst is executed
+	// if enough detection results were successfully
+	adcsReadyForNewBurst = adcsResults->validMeasurementsCount > adcsSettings.nbMeasurements/2 ? 0 : 1;
+
+	cubeSenseIsInUse = 0;
+	return SUCCESS;
+}
+
+
+/*
+ * Get the ADCS burst measurement results.
+ */
+adcs_detection_results_t * getADCSBurstResults(void) {
+	return adcsResults;
+}
+
+
+/*
+ * Memory allocation and initialization of a new ADCS results structure
+ *
+ * @note it is important to free the allocated pointer memory after usage
+ * @param nbMeasurements defines the number of measurements desired
+ * @return pointer to the new ADCS results struct in memory
+ */
+adcs_detection_results_t * initializeNewADCSResults(uint8_t nbMeasurements) {
+	adcs_detection_results_t *adcs = calloc(1, sizeof(*adcs) + sizeof(detection_results_t) * nbMeasurements);
+	printf("ADCS Results allocated memory size = %i bytes\n", sizeof(*adcs) + sizeof(detection_results_t) * nbMeasurements);
+	return adcs;
+}
+
+
+/*
+ * Set the flag indicating that ADCS is ready for a new burst of measurements.
+ */
+void setADCSReadyForNewBurst(void) {
+	adcsReadyForNewBurst = 1;
+}
+
+
+/*
+ * Get the flag indicating if ADCS is ready for a new burst.
+ * This flag needs to be reset to 1 via a telecommand.
+ *
+ * @return ADCS readiness, 1 for ready, 0 for not ready
+ */
+uint8_t getADCSReadyForNewBurstState(void) {
+	return adcsReadyForNewBurst;
+}
+
+
+/*
+ * Set the interval used for automatic image capture.
+ */
+void setImageCaptureInterval(int interval) {
+	imageCaptureInterval = interval;
+}
+
+
+/*
+ * Get the interval used for automatic image capture.
+ *
+ * @return interval, in milliseconds
+ */
+int getImageCaptureInterval(void) {
+	return imageCaptureInterval;
+}
+
+
+/*
+ * Set the image download size used for automatic image capture.
+ *
+ * @return error, 0 for success, 1 for failure
+ */
+int setImageDownloadSize(uint8_t size) {
+	// Check for invalid size
+	if (size > 4)
+		return 1;
+
+	imageDownloadSize = size;
+	return SUCCESS;
+}
+
+
+/*
+ * Get the image download size used for automatic image capture.
+ *
+ * @return size, ranging from 0 to 4 (see CubeSense's manual)
+ */
+uint8_t getImageDownloadSize(void) {
+	return imageDownloadSize;
+}
+
+
+/*
+ * Trigger a new image capture given the specified parameters.
+ *
+ * @param camera defines which sensor to use to capture an image, 0 = Camera 1, 1 = Camera 2
+ * @param sram defines which SRAM to use on CubeSense, 0 = SRAM1, 1 = SRAM2
+ * @param size defines the image size used to allocate memory, 0 = 1024x1024, 1 = 512x512, 2 = 256x256, 3 = 128x128, 4 = 64x64
+ * @param location defines which SRAM slot to use within selected SRAM, 0 = top, 1 = bottom
+ * @return error, 0 on success, otherwise failure
+ */
+int requestImageCapture(uint8_t camera, uint8_t sram, uint8_t location) {
+	return captureImage(camera, sram, location);
+}
+
+
+/*
+ * Trigger a new image capture given the specified parameters, run
+ * the detection algorithm on said image, and download the image into RAM.
+ *
+ * @param camera defines which sensor to use to capture an image, 0 = Camera 1, 1 = Camera 2
+ * @param sram defines which SRAM to use on CubeSense, 0 = SRAM1, 1 = SRAM2
+ * @param size defines the image size used to allocate memory, 0 = 1024x1024, 1 = 512x512, 2 = 256x256, 3 = 128x128, 4 = 64x64
+ * @return error, 0 on success, otherwise failure
+ */
+int requestImageCaptureDetectAndDownload(uint8_t camera, uint8_t sram, uint8_t size) {
+	int error = requestImageCaptureAndDetect(camera, sram);
+	if (error != SUCCESS) {
+		return error;
+	}
+
+	error = requestImageDownload(sram, size);
+	if (error != SUCCESS) {
+		return error;
+	}
+
+	return SUCCESS;
+}
+
+
+/*
+ * Trigger a new image capture given the specified parameters
+ * and run the detection algorithm on said image.
+ * Once we have successful detection, another picture is taken in the bottom SRAM location.
+ *
+ * @param camera defines which sensor to use to capture an image, 0 = Camera 1, 1 = Camera 2
+ * @param sram defines which SRAM to use on CubeSense, 0 = SRAM1, 1 = SRAM2
+ * @return error, 0 on success, otherwise failure
+ */
+int requestImageCaptureAndDetect(uint8_t camera, uint8_t sram) {
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	int error;
+	uint8_t retryCount = 0;
+	uint8_t detectionStatus = 1;
+
+	// Capture an image and run the detection algorithm to get the results
+	// Retry a few times if results are invalid
+	while (detectionStatus != 0 && retryCount < VALID_IMAGE_RETRY_COUNT) {
+		printf("\nImage capture attempt: %d\n", retryCount);
+		// Capture image
+		error = captureImageAndDetect(camera, sram);
+		if (error == SUCCESS) {
+			// Wait to allow the image capture to complete
+			vTaskDelay(IMAGE_CAPTURE_DELAY_MS);
+
+			// Get the detection status using the nadir sensor
+			detectionStatus = getSingleDetectionStatus(camera == 0 ? sensor1 : sensor2);
+		} else {
+			printf("Failed during image capture...\n");
+		}
+
+		// Wait before a retry
+		vTaskDelay(IMAGE_CAPTURE_DELAY_MS);
+
+		// Increase retry counter
+		retryCount++;
+	}
+
+	// Detection results are still invalid, stop trying
+	if (detectionStatus != 0) {
+		printf("Failed to capture a valid image...\n");
+		// Flag CubeSense as "not used"
+		cubeSenseIsInUse = 0;
+		return E_GENERIC;
+	}
+
+	// Detection success, so take another image in the bottom location
+	error = requestImageCapture(camera, sram, BOTTOM_HALVE);
+	if (error != SUCCESS) {
+		printf("Failed to capture image in bottom location...\n");
+	} else {
+		printf("Successfully captured image in bottom location.\n");
+	}
+	vTaskDelay(IMAGE_CAPTURE_DELAY_MS);
+
+	// Flag CubeSense as "not used"
+	cubeSenseIsInUse = 0;
+
+	// Reset flag so no new capture is made
+	imageReadyForNewCapture = 0;
+	return SUCCESS;
+}
+
+
+/*
+ * Start the download of the image into RAM.
+ *
+ * @param sram defines which SRAM to use on CubeSense, 0 = SRAM1, 1 = SRAM2
+ * @param size defines the image size used to allocate memory, 0 = 1024x1024, 1 = 512x512, 2 = 256x256, 3 = 128x128, 4 = 64x64
+ * @return error, 0 on success, otherwise failure
+ */
+int requestImageDownload(uint8_t sram, uint8_t size) {
+	// Store the download parameters to be used by the image download task
+	downloadParameters.sram = sram;
+	downloadParameters.size = size;
+
+	// Create a task to download an image from CubeSense
+	int error = xTaskCreate(ImageDownloadTask,
+							(const signed char*)"Image Download Task",
+							DOWNLOAD_TASK_STACK_SIZE,
+							NULL,
+							imageDownloadTaskPriority,
+							&imageDownloadTaskHandle);
+	if (error != pdPASS) {
+		debugPrint("requestImageDownload(): failed to create ImageDownloadTask.\n");
+		return E_GENERIC;
+	}
+
+	return SUCCESS;
+}
+
+
+/*
+ * Clear the image stored and memory.
+ */
+void clearImage(void) {
+	// Reset the image downlink ready flag since allocated memory is freed
+	imageReadyForDownlink = 0;
+	// Free the previous image allocated memory
+	free(image);
+	// Reset the image frame index
+	currentImageFrameIndex = MAX_FRAME_INDEX;
+}
+
+
+/*
+ * Set the image ready for new capture flag.
+ */
+void setImageReadyForNewCapture(void) {
+	imageReadyForNewCapture = 1;
+}
+
+
+/*
+ * Get the image ready for new capture flag.
+ *
+ * @return ready for new capture state, 0 for not ready, 1 for ready
+ */
+uint8_t getImageReadyForNewCaptureState(void) {
+	return imageReadyForNewCapture;
+}
+
+
+/*
+ * Get the ready for downlink state of the stored image.
+ *
+ * @return ready for downlink state, 0 for not ready, 1 for ready
+ */
+uint8_t getImageReadyForDownlinkState(void) {
+	return imageReadyForDownlink;
+}
+
+
+/*
+ * Get the total number of image frames available for downlink.
+ *
+ * @return number of image frames
+ */
+uint16_t getImageFramesCount(void) {
+	// Check stored image validity
+	if (!imageReadyForDownlink)
+		return 0;
+
+	return image->framesCount;
+}
+
+
+/*
+ * Get the CubeSense usage state. This should be used to prevent
+ * different CubeSense functions being called at the same time.
+ *
+ * @return CubeSense usage, 1 if CubeSense is in use, 0 if it's unused
+ */
+uint8_t getCubeSenseUsageState(void) {
+	return cubeSenseIsInUse;
+}
+
+
+/*
+ * Set the image transfer frame index to the specified value.
+ *
+ * @param index defines the value to set the image transfer frame index
+ */
+void setImageTransferFrameIndex(uint16_t index) {
+	currentImageFrameIndex = index;
+}
+
+/**
+ * Provide the next image frame.
+ *
+ * @param frame pointer to a buffer that the frame will be placed into. Set by function.
+ * @return The size of the image frame placed into the buffer; 0 on error.
+ */
+uint8_t imageTransferNextFrame(uint8_t* frame) {
+	// Check stored image validity
+	if (!imageReadyForDownlink)
+		return 0;
+
+	// Validate that there is a next frame
+	uint16_t nextFrameIndex = currentImageFrameIndex + 1;
+	if (nextFrameIndex >= image->framesCount)
+		return 0;
+
+	// Increment image frame index
+	currentImageFrameIndex++;
+
+	// Get image frame size
+	uint8_t size = sizeof(image->imageFrames[currentImageFrameIndex].image_bytes);
+
+	// Copy the image frame to the argument pointer
+	printf("Copying image frame index %i containing %i bytes.\n", currentImageFrameIndex, size);
+	memcpy(frame, image->imageFrames[currentImageFrameIndex].image_bytes, size);
+
+	// Return size of the frame
+	return size;
+}
+
+
+/**
+ * Provide the current image frame.
+ *
+ * @param frame pointer to a buffer that the frame will be placed into. Set by function.
+ * @return The size of the image frame placed into the buffer; 0 on error.
+ */
+uint8_t imageTransferCurrentFrame(uint8_t* frame) {
+	return imageTransferSpecificFrame(frame, currentImageFrameIndex);
+}
+
+
+/**
+ * Provide the image frame at the specified index.
+ *
+ * @param frame pointer to a buffer that the frame will be placed into. Set by function.
+ * @param index defines which image frame to copy in the buffer
+ * @return The size of the image frame placed into the buffer; 0 on error.
+ */
+uint8_t imageTransferSpecificFrame(uint8_t* frame, uint16_t index) {
+	// Check stored image validity
+	if (!imageReadyForDownlink)
+		return 0;
+
+	// Validate image frame index
+	if (index >= image->framesCount)
+		return 0;
+
+	// Get image frame size
+	uint8_t size = sizeof(image->imageFrames[index].image_bytes);
+
+	// Copy the image frame to the argument pointer
+	printf("\nCopying image frame index %i containing %i bytes.\n", index, size);
+	memcpy(frame, image->imageFrames[index].image_bytes, size);
+
+	// Return size of the frame
+	return size;
+}
+
+/***************************************************************************************************
+                                           FREERTOS TASKS
+***************************************************************************************************/
+
+/*
+ * Task to download an image from CubeSense into RAM.
+ *
+ * @param parameters defines the task parameters (unused)
+ */
+void ImageDownloadTask(void* parameters) {
+	// Flag CubeSense as "in use"
+	cubeSenseIsInUse = 1;
+
+	// ignore the input parameter
+	(void)parameters;
+
+	printf("ImageDownloadTask 1: SRAM = %i | Size = %i\n", downloadParameters.sram, downloadParameters.size);
+
+	// Clear the stored image & reset flag and index
+	clearImage();
+	// Initialize a new block of memory for the new image
+	image = initializeNewImage(downloadParameters.size);
+	// Download all image frames and store them in RAM
+	int error = downloadImage(downloadParameters.sram, BOTTOM_HALVE, image);
+	if (error != SUCCESS) {
+		printf("\nImageDownloadTask(): Failed to download all image frames...\n");
+		// TODO:
+		// - Clear the image struct? Keep it as is? Free allocated memory?
+		// - ErrorManager?
+	} else {
+		printf("\nImageDownloadTask(): Successfully downloaded image!\n");
+
+		// Flag the stored image as valid
+		imageReadyForDownlink = 1;
+	}
+
+	// Flag CubeSense as "not used"
+	cubeSenseIsInUse = 0;
+
+	// Let this task delete itself
+	vTaskDelete(imageDownloadTaskHandle);
+}

--- a/radsat-sk/operation/services/RCameraService.c
+++ b/radsat-sk/operation/services/RCameraService.c
@@ -137,10 +137,6 @@ int setCamerasSettings(CameraSettings_ConfigurationSettings sunSettings, CameraS
 	cameraSettings.cameraOneSettings = sunSettings;
 	cameraSettings.cameraTwoSettings = nadirSettings;
 
-	// TODO: TO DELETE
-	//cameraSettings.cameraTwoSettings.exposure = 10000;
-	//cameraSettings.cameraTwoSettings.detectionThreshold = 150;
-
 	error = setSettings(&cameraSettings);
 	cubeSenseIsInUse = 0;
 	if (error != SUCCESS) {

--- a/radsat-sk/operation/services/RCameraService.h
+++ b/radsat-sk/operation/services/RCameraService.h
@@ -1,0 +1,67 @@
+/**
+ * @file RCameraService.h
+ * @date September 28, 2022
+ * @author
+ */
+
+#ifndef RCAMERASERVICE_H_
+#define RCAMERASERVICE_H_
+
+#include <RCamera.h>
+#include <stdint.h>
+
+/***************************************************************************************************
+                                            DEFINITIONS
+***************************************************************************************************/
+
+/** Struct that holds an arbitrary number of ADCS measurement results **/
+typedef struct _adcs_detection_results_t {
+	uint8_t validMeasurementsCount;
+	detection_results_t results[];
+} adcs_detection_results_t;
+
+/***************************************************************************************************
+                                             PUBLIC API
+***************************************************************************************************/
+
+/** General functions **/
+int requestReset(uint8_t resetOption);
+int setCamerasSettings(CameraSettings newSettings);
+/***********************/
+
+/** ADCS Capture functions **/
+void setADCSCaptureSettings(uint8_t nbMeasurements, int interval);
+int takeADCSBurstMeasurements(void);
+adcs_detection_results_t * getADCSBurstResults(void);
+adcs_detection_results_t * initializeNewADCSResults(uint8_t nbMeasurements);
+
+void setADCSReadyForNewBurst(void);
+uint8_t getADCSReadyForNewBurstState(void);
+/****************************/
+
+/** Image Capture functions **/
+void setImageCaptureInterval(int interval);
+int getImageCaptureInterval(void);
+
+int setImageDownloadSize(uint8_t size);
+uint8_t getImageDownloadSize(void);
+
+int requestImageCapture(uint8_t camera, uint8_t sram, uint8_t location);
+int requestImageCaptureDetectAndDownload(uint8_t camera, uint8_t sram, uint8_t size);
+int requestImageCaptureAndDetect(uint8_t camera, uint8_t sram);
+int requestImageDownload(uint8_t sram, uint8_t size);
+void clearImage(void);
+
+void setImageReadyForNewCapture(void);
+uint8_t getImageReadyForNewCaptureState(void);
+uint8_t getImageReadyForDownlinkState(void);
+uint16_t getImageFramesCount(void);
+uint8_t getCubeSenseUsageState(void);
+
+void setImageTransferFrameIndex(uint16_t index);
+uint8_t imageTransferNextFrame(uint8_t* frame);
+uint8_t imageTransferCurrentFrame(uint8_t* frame);
+uint8_t imageTransferSpecificFrame(uint8_t* frame, uint16_t index);
+/*****************************/
+
+#endif /* RCAMERASERVICE_H_ */

--- a/radsat-sk/operation/services/RCameraService.h
+++ b/radsat-sk/operation/services/RCameraService.h
@@ -14,11 +14,17 @@
                                             DEFINITIONS
 ***************************************************************************************************/
 
-/** Struct that holds an arbitrary number of ADCS measurement results **/
+/** Struct prepared for downlink that holds the ADCS measurement results **/
 typedef struct _adcs_detection_results_t {
 	uint8_t validMeasurementsCount;
-	detection_results_t results[];
+	detection_results_t results[];  // Variable size, corresponding to the number of measurements in a burst
 } adcs_detection_results_t;
+
+/* Struct prepared for downlink that holds an image frame */
+typedef struct _image_frame_t {
+	uint16_t frameIndex;
+	uint8_t image_bytes[FRAME_BYTES];
+} image_frame_t;
 
 /***************************************************************************************************
                                              PUBLIC API
@@ -26,11 +32,14 @@ typedef struct _adcs_detection_results_t {
 
 /** General functions **/
 int requestReset(uint8_t resetOption);
-int setCamerasSettings(CameraSettings newSettings);
+int setCamerasSettings(CameraSettings_ConfigurationSettings sunSettings, CameraSettings_ConfigurationSettings nadirSettings);
 /***********************/
 
 /** ADCS Capture functions **/
-void setADCSCaptureSettings(uint8_t nbMeasurements, int interval);
+void setADCSCaptureInterval(int interval);
+int getADCSCaptureInterval(void);
+
+void setADCSBurstSettings(uint8_t nbMeasurements, int interval);
 int takeADCSBurstMeasurements(void);
 adcs_detection_results_t * getADCSBurstResults(void);
 adcs_detection_results_t * initializeNewADCSResults(uint8_t nbMeasurements);
@@ -43,14 +52,13 @@ uint8_t getADCSReadyForNewBurstState(void);
 void setImageCaptureInterval(int interval);
 int getImageCaptureInterval(void);
 
-int setImageDownloadSize(uint8_t size);
+void setImageDownloadSize(uint8_t size);
 uint8_t getImageDownloadSize(void);
 
 int requestImageCapture(uint8_t camera, uint8_t sram, uint8_t location);
 int requestImageCaptureDetectAndDownload(uint8_t camera, uint8_t sram, uint8_t size);
 int requestImageCaptureAndDetect(uint8_t camera, uint8_t sram);
 int requestImageDownload(uint8_t sram, uint8_t size);
-void clearImage(void);
 
 void setImageReadyForNewCapture(void);
 uint8_t getImageReadyForNewCaptureState(void);
@@ -58,10 +66,10 @@ uint8_t getImageReadyForDownlinkState(void);
 uint16_t getImageFramesCount(void);
 uint8_t getCubeSenseUsageState(void);
 
-void setImageTransferFrameIndex(uint16_t index);
-uint8_t imageTransferNextFrame(uint8_t* frame);
-uint8_t imageTransferCurrentFrame(uint8_t* frame);
-uint8_t imageTransferSpecificFrame(uint8_t* frame, uint16_t index);
+void setImageTransferFrameIndex(int index);
+uint8_t imageTransferNextFrame(image_frame_t* frame);
+uint8_t imageTransferCurrentFrame(image_frame_t* frame);
+uint8_t imageTransferSpecificFrame(image_frame_t* frame, int index);
 /*****************************/
 
 #endif /* RCAMERASERVICE_H_ */

--- a/radsat-sk/operation/services/RTelecommandService.c
+++ b/radsat-sk/operation/services/RTelecommandService.c
@@ -5,7 +5,9 @@
  */
 
 #include <RTelecommandService.h>
+#include <RCameraService.h>
 #include <RMessage.h>
+#include <stdio.h>
 
 
 /***************************************************************************************************
@@ -20,6 +22,7 @@
  * @return The tag of the processed telecommand (0 on failure).
  */
 uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
+	int error;
 
 	// ensure the input pointer is not NULL
 	if (wrappedMessage == 0)
@@ -74,6 +77,90 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 		case (telecommand_message_Reset_tag):
 			// TODO: implement functionality
 			break;
+
+
+
+		// TO ADD: Reset cameras
+		case (255):
+			// TODO: Pass argument (reset option)
+			if (!getCubeSenseUsageState()) {
+				error = requestReset(2);
+				if (error != 0) {
+					printf("Error resetting cameras.\n");
+				}
+			}
+			break;
+
+		// TO ADD: Change both cameras' settings
+		case (254):
+			// TODO: Pass arguments (CameraSettings struct)
+			if (!getCubeSenseUsageState()) {
+				error = setCamerasSettings((CameraSettings){0});
+				if (error != 0) {
+					printf("Error updating cameras settings.\n");
+				}
+			}
+			break;
+
+		// TO ADD: Change automatic image capture interval
+		case (253):
+			// TODO: Pass argument (interval in ms)
+			setImageCaptureInterval(0);
+			break;
+
+		// TO ADD: Change automatic image download size
+		case (252):
+			// TODO: Pass argument (0, 1, 2, 3 or 4)
+			error = setImageDownloadSize(0);
+			if (error != 0) {
+				printf("Invalid image download size.\n");
+			}
+			break;
+
+		// TO ADD: Set image as ready for a new capture
+		case (251):
+			setImageReadyForNewCapture();
+			break;
+
+		// TO ADD: Change image transfer frame index
+		case (250):
+			// TODO: Pass argument (frame index)
+			setImageTransferFrameIndex(0);
+			break;
+
+		// TO ADD: Take manual image
+		case (249):
+			// TODO: Pass arguments?
+			if (!getCubeSenseUsageState()) {
+				error = requestImageCapture(NADIR_SENSOR, SRAM2, BOTTOM_HALVE);
+				if (error != 0) {
+					printf("Failed to manually capture an image...\n");
+				}
+			}
+			break;
+
+		// TO ADD: Manually start the download of an image
+		case (248):
+			// TODO: Pass arguments (image size)
+			if (!getCubeSenseUsageState()) {
+				error = requestImageDownload(SRAM2, 0);
+				if (error != 0) {
+					printf("Failed to start the image download...\n");
+				}
+			}
+			break;
+
+		// TO ADD: Update ADCS settings
+		case (247):
+			// TODO: Pass arguments (nb of measurements in a burst, interval between measurements)
+			setADCSCaptureSettings(5, 2000);
+			break;
+
+		// TO ADD: Reset the adcs readiness flag so it can take another burst of measurements
+		case (246):
+			setADCSReadyForNewBurst();
+			break;
+
 
 		// unknown telecommand
 		default:

--- a/radsat-sk/operation/services/RTelecommandService.c
+++ b/radsat-sk/operation/services/RTelecommandService.c
@@ -79,12 +79,12 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 			break;
 
 
-
+/*
 		// TO ADD: Reset cameras
-		case (255):
+		case (?):
 			// TODO: Pass argument (reset option)
 			if (!getCubeSenseUsageState()) {
-				error = requestReset(2);
+				error = requestReset(resetOption);
 				if (error != 0) {
 					printf("Error resetting cameras.\n");
 				}
@@ -92,9 +92,10 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 			break;
 
 		// TO ADD: Change both cameras' settings
-		case (254):
+		case (?):
 			// TODO: Pass arguments (2x CameraSettings_ConfigurationSettings struct)
 			if (!getCubeSenseUsageState()) {
+				// TODO: To replace with passed arguments
 				CameraSettings_ConfigurationSettings sunSettings = {0};
 				CameraSettings_ConfigurationSettings nadirSettings = {0};
 				error = setCamerasSettings(sunSettings, nadirSettings);
@@ -105,30 +106,30 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 			break;
 
 		// TO ADD: Change automatic image capture interval
-		case (253):
+		case (?):
 			// TODO: Pass argument (interval in ms)
-			setImageCaptureInterval(0);
+			setImageCaptureInterval(interval);
 			break;
 
 		// TO ADD: Change automatic image download size
-		case (252):
+		case (?):
 			// TODO: Pass argument (0, 1, 2, 3 or 4)
-			setImageDownloadSize(0);
+			setImageDownloadSize(downloadSize);
 			break;
 
 		// TO ADD: Set image as ready for a new capture
-		case (251):
+		case (?):
 			setImageReadyForNewCapture();
 			break;
 
 		// TO ADD: Change image transfer frame index
-		case (250):
+		case (?):
 			// TODO: Pass argument (frame index)
-			setImageTransferFrameIndex(0);
+			setImageTransferFrameIndex(frameIndex);
 			break;
 
 		// TO ADD: Take manual image
-		case (249):
+		case (?):
 			if (!getCubeSenseUsageState()) {
 				error = requestImageCapture(NADIR_SENSOR, SRAM2, BOTTOM_HALVE);
 				if (error != 0) {
@@ -138,10 +139,10 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 			break;
 
 		// TO ADD: Manually start the download of an image
-		case (248):
+		case (?):
 			// TODO: Pass arguments (image size)
 			if (!getCubeSenseUsageState()) {
-				error = requestImageDownload(SRAM2, 0);
+				error = requestImageDownload(SRAM2, imageSize);
 				if (error != 0) {
 					printf("Failed to start the image download...\n");
 				}
@@ -149,17 +150,18 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 			break;
 
 		// TO ADD: Update ADCS settings
-		case (247):
+		case (?):
 			// TODO: Pass arguments (nb of measurements in a burst, interval between measurements)
-			setADCSBurstSettings(5, 5000);
+			setADCSBurstSettings(nbMeasurements, interval);
 			break;
 
 		// TO ADD: Reset the adcs readiness flag so it can take another burst of measurements
-		case (246):
+		case (?):
 			setADCSReadyForNewBurst();
 			break;
 
 		// TODO: Implement missing camera telecommands
+*/
 
 
 		// unknown telecommand

--- a/radsat-sk/operation/services/RTelecommandService.c
+++ b/radsat-sk/operation/services/RTelecommandService.c
@@ -93,9 +93,11 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 
 		// TO ADD: Change both cameras' settings
 		case (254):
-			// TODO: Pass arguments (CameraSettings struct)
+			// TODO: Pass arguments (2x CameraSettings_ConfigurationSettings struct)
 			if (!getCubeSenseUsageState()) {
-				error = setCamerasSettings((CameraSettings){0});
+				CameraSettings_ConfigurationSettings sunSettings = {0};
+				CameraSettings_ConfigurationSettings nadirSettings = {0};
+				error = setCamerasSettings(sunSettings, nadirSettings);
 				if (error != 0) {
 					printf("Error updating cameras settings.\n");
 				}
@@ -111,10 +113,7 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 		// TO ADD: Change automatic image download size
 		case (252):
 			// TODO: Pass argument (0, 1, 2, 3 or 4)
-			error = setImageDownloadSize(0);
-			if (error != 0) {
-				printf("Invalid image download size.\n");
-			}
+			setImageDownloadSize(0);
 			break;
 
 		// TO ADD: Set image as ready for a new capture
@@ -130,7 +129,6 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 
 		// TO ADD: Take manual image
 		case (249):
-			// TODO: Pass arguments?
 			if (!getCubeSenseUsageState()) {
 				error = requestImageCapture(NADIR_SENSOR, SRAM2, BOTTOM_HALVE);
 				if (error != 0) {
@@ -153,13 +151,15 @@ uint8_t telecommandHandle(uint8_t* wrappedMessage, uint8_t size) {
 		// TO ADD: Update ADCS settings
 		case (247):
 			// TODO: Pass arguments (nb of measurements in a burst, interval between measurements)
-			setADCSCaptureSettings(5, 2000);
+			setADCSBurstSettings(5, 5000);
 			break;
 
 		// TO ADD: Reset the adcs readiness flag so it can take another burst of measurements
 		case (246):
 			setADCSReadyForNewBurst();
 			break;
+
+		// TODO: Implement missing camera telecommands
 
 
 		// unknown telecommand

--- a/radsat-sk/operation/subsystems/camera/RADCS.h
+++ b/radsat-sk/operation/subsystems/camera/RADCS.h
@@ -4,32 +4,21 @@
  * @author Addi Amaya (Caa746)
  */
 
+#include <RCameraCommon.h>
+#include <time.h>
+
 /***************************************************************************************************
                                             DEFINITIONS
 ***************************************************************************************************/
 
-/* Enum of telemetry request ID for sensor result and new detection */
-typedef enum _SensorResultAndDetection {
-	sensor1_sram1  = 0x96, // TLM 22
-	sensor2_sram2  = 0x97, // TLM 23
-	sensor1_sram2  = 0x98, // TLM 24
-	sensor2_sram1  = 0x99  // TLM 25
-} SensorResultAndDetection;
-
 /* Struct for telemetry Detection result and Trigger, ID 20-25 */
 typedef struct _tlm_detection_result_and_trigger_adcs_t {
+	uint32_t timestamp;
 	uint16_t alpha;
 	uint16_t beta;
 	uint8_t captureResult;
 	uint8_t detectionResult;
 } tlm_detection_result_and_trigger_adcs_t;
-
-/* Struct to define 3D vector */
-typedef struct _interpret_detection_result_t {
-	float X_AXIS;
-	float Y_AXIS;
-	float Z_AXIS;
-} interpret_detection_result_t;
 
 /***************************************************************************************************
                                              PUBLIC API
@@ -37,4 +26,4 @@ typedef struct _interpret_detection_result_t {
 
 int tcImageCaptureAndDetection(uint8_t camera, uint8_t sram);
 int tlmSensorResultAndDetection(tlm_detection_result_and_trigger_adcs_t *telemetry_reply, SensorResultAndDetection sensorSelection);
-interpret_detection_result_t calculateDetectionVector(uint16_t alpha, uint16_t beta);
+//interpret_detection_result_t calculateDetectionVector(uint16_t alpha, uint16_t beta);

--- a/radsat-sk/operation/subsystems/camera/RCamera.h
+++ b/radsat-sk/operation/subsystems/camera/RCamera.h
@@ -7,7 +7,9 @@
 #ifndef RCAMERA_H_
 #define RCAMERA_H_
 
+#include <RCameraCommon.h>
 #include <stdint.h>
+#include <time.h>
 
 /***************************************************************************************************
                                             DEFINITIONS
@@ -18,43 +20,43 @@
 /*maximum number of bytes in one image */
 #define MAXIMUM_BYTES					1048576
 
-/* Struct used to define ADCS Function*/
+/* Struct used to hold the successful image detection angles */
 typedef struct _detection_results_t {
-	float sunSensorX;
-	float sunSensorY;
-	float sunSensorZ;
-	float nadirSensorX;
-	float nadirSensorY;
-	float nadirSensorZ;
+	uint32_t sunTimestamp;
+	uint16_t sunAlphaAngle;
+	uint16_t sunBetaAngle;
+	uint32_t nadirTimestamp;
+	uint16_t nadirAlphaAngle;
+	uint16_t nadirBetaAngle;
 } detection_results_t;
 
-/* Struct that holds all power related telemetry */
-typedef struct _CameraTelemetry_PowerTelemetry {
+/* Struct that holds all power related settings */
+typedef struct _CameraSettings_PowerSettings {
     float current_3V3;
     float current_5V;
     float current_SRAM_1;
     float current_SRAM_2;
     uint8_t overcurrent_SRAM_1;
     uint8_t overcurrent_SRAM_2;
-} CameraTelemetry_PowerTelemetry;
+} CameraSettings_PowerSettings;
 
-/* Struct that holds all Camera configuration related telemetry */
-typedef struct _CameraTelemetry_ConfigurationTelemetry {
+/* Struct that holds all Camera configuration related settings */
+typedef struct _CameraSettings_ConfigurationSettings {
     uint8_t detectionThreshold;
     uint8_t autoAdjustMode;
     uint16_t exposure;
     uint8_t autoGainControl;
     uint8_t blueGain;
     uint8_t redGain;
-} CameraTelemetry_ConfigurationTelemetry;
+} CameraSettings_ConfigurationSettings;
 
-/* Struct for Camera Telemetry Collection Function */
-typedef struct _CameraTelemetry {
+/* Struct for Camera Settings Collection Function */
+typedef struct _CameraSettings {
     uint16_t upTime;
-    CameraTelemetry_PowerTelemetry powerTelemetry;
-    CameraTelemetry_ConfigurationTelemetry cameraOneTelemetry;
-    CameraTelemetry_ConfigurationTelemetry cameraTwoTelemetry;
-} CameraTelemetry;
+    CameraSettings_PowerSettings powerSettings;
+    CameraSettings_ConfigurationSettings cameraOneSettings;
+    CameraSettings_ConfigurationSettings cameraTwoSettings;
+} CameraSettings;
 
 /* Struct for telemetry image frame */
 typedef struct _tlm_image_frame_t {
@@ -75,10 +77,13 @@ typedef struct _full_image_t {
 
 full_image_t * initializeNewImage(uint8_t size);
 int captureImage(uint8_t camera, uint8_t sram, uint8_t location);
+int captureImageAndDetect(uint8_t camera, uint8_t sram);
 int downloadImage(uint8_t sram, uint8_t location, full_image_t *image);
+int getSingleDetectionStatus(SensorResultAndDetection sensorSelection);
 int getResultsAndTriggerNewDetection(detection_results_t *data);
-int setCameraConfig(CameraTelemetry *cameraTelemetry);
-int getCameraTelemetry(CameraTelemetry *cameraTelemetry);
+int triggerNewDetectionForBothSensors(void);
+int setSettings(CameraSettings *cameraSettings);
+int getSettings(CameraSettings *cameraSettings);
 int executeReset(uint8_t resetOption);
 
 #endif /* RCAMERA_H_ */

--- a/radsat-sk/operation/subsystems/camera/RCameraCommon.h
+++ b/radsat-sk/operation/subsystems/camera/RCameraCommon.h
@@ -58,6 +58,23 @@
 #define TOP_HALVE                       ((uint8_t) 0)
 #define BOTTOM_HALVE                    ((uint8_t) 1)
 
+/* Enum of telemetry request ID for sensor result and new detection */
+typedef enum _SensorResultAndDetection {
+	sensor1        = 0x94, // TLM 20 (no new detection)
+	sensor2        = 0x95, // TLM 21 (no new detection)
+	sensor1_sram1  = 0x96, // TLM 22
+	sensor2_sram2  = 0x97, // TLM 23
+	sensor1_sram2  = 0x98, // TLM 24
+	sensor2_sram1  = 0x99  // TLM 25
+} SensorResultAndDetection;
+
+/* Struct to define 3D vector */
+typedef struct _interpret_detection_result_t {
+	float X_AXIS;
+	float Y_AXIS;
+	float Z_AXIS;
+} interpret_detection_result_t;
+
 /****************************************************************************************************
                                              PUBLIC API
 ***************************************************************************************************/

--- a/radsat-sk/operation/subsystems/camera/RImage.c
+++ b/radsat-sk/operation/subsystems/camera/RImage.c
@@ -204,6 +204,7 @@ int tcInitImageDownload(uint8_t SRAM, uint8_t location, uint8_t size) {
 	free(telecommandBuffer);
 
 	if (error != 0) {
+		printf("tcInitImageDownload(): Error during uartTransmit()...\n");
 		return E_GENERIC;
 	}
 
@@ -215,6 +216,7 @@ int tcInitImageDownload(uint8_t SRAM, uint8_t location, uint8_t size) {
 	error = uartReceive(UART_CAMERA_BUS, telecommandResponse, sizeOfBuffer);
 
 	if (error != 0) {
+		printf("tcInitImageDownload(): Error during uartReceive()...");
 		free(telecommandResponse);
 		return E_GENERIC;
 	}
@@ -226,6 +228,7 @@ int tcInitImageDownload(uint8_t SRAM, uint8_t location, uint8_t size) {
 	free(telecommandResponse);
 
 	if (tcErrorFlag != 0) {
+		printf("tcInitImageDownload(): Bad tcErrorFlag...\n");
 		return E_GENERIC;
 	}
 
@@ -261,6 +264,7 @@ int tlmImageFrameInfo(tlm_image_frame_info_t *telemetry_reply) {
 	free(telemetryBuffer);
 
 	if (error != 0) {
+		printf("tlmImageFrameInfo(): Error during uartTransmit()... (error=%d)\n", error);
 		return E_GENERIC;
 	}
 
@@ -271,6 +275,7 @@ int tlmImageFrameInfo(tlm_image_frame_info_t *telemetry_reply) {
 	error = receiveAndUnescapeTelemetry(telemetryBuffer, TELEMETRY_65_LEN);
 
 	if (error != 0) {
+		printf("tlmImageFrameInfo(): Error during receiveAndUnescapeTelemetry()... (error=%d)\n", error);
 		free(telemetryBuffer);
 		return E_GENERIC;
 	}

--- a/radsat-sk/src/tasks/RAdcsCaptureTask.c
+++ b/radsat-sk/src/tasks/RAdcsCaptureTask.c
@@ -5,6 +5,7 @@
  */
 
 #include <RAdcsCaptureTask.h>
+#include <RCameraService.h>
 #include <RCommon.h>
 #include <RCamera.h>
 #include <freertos/FreeRTOS.h>
@@ -16,10 +17,13 @@
 ***************************************************************************************************/
 
 /** How many ADCS readings to capture per hour. */
-#define ADCS_CAPTURES_PER_HOUR	(1)
+#define ADCS_CAPTURES_PER_HOUR					(1)
 
-/** ADCS Capture Task delay (in ms). */
-#define ADCS_CAPTURE_TASK_DELAY_MS	(MS_PER_HOUR / ADCS_CAPTURES_PER_HOUR)
+/** ADCS Capture Task normal delay (in ms). */
+#define ADCS_CAPTURE_TASK_NORMAL_DELAY_MS		(MS_PER_HOUR / ADCS_CAPTURES_PER_HOUR)
+
+/** ADCS Capture Task short delay (in ms). */
+#define ADCS_CAPTURE_TASK_SHORT_DELAY_MS		(10000)
 
 
 /***************************************************************************************************
@@ -27,19 +31,63 @@
 ***************************************************************************************************/
 
 void AdcsCaptureTask(void* parameters) {
+	int error;
 
 	// ignore the input parameter
 	(void)parameters;
 
+	// Initialize the ADCS capture settings (5 measurements, 5 seconds between measurements)
+	setADCSCaptureSettings(5, 5000);
+
 	while (1) {
 
-		// TODO: implement ADCS capture
+		// TODO: Uncomment function call when Brian's branch will be ready/merged
+		// Check if satellite is currently in downlink/uplink mode (1) or not (0)
+		uint8_t commIsActive = 0; //communicationPassModeActive();
 
-		debugPrint("AdcsCaptureTask(): About to capture ADCS data.\n");
+		// Check if CubeSense is already in use (1) or not (0)
+		uint8_t cubeSenseIsInUse = getCubeSenseUsageState();
+		printf("AdcsCaptureTask(): cubeSenseIsInUse = %d\n", cubeSenseIsInUse);
 
-		// TODO
-		// To get detection results and trigger new detection, use --> "getResultsAndTriggerNewDetection(...)"
+		// Check if ready for a new ADCS burst measurements (1) or not (0)
+		uint8_t adcsReadyForNewBurst = getADCSReadyForNewBurstState();
 
-		vTaskDelay(ADCS_CAPTURE_TASK_DELAY_MS);
+		if (!commIsActive && !cubeSenseIsInUse && adcsReadyForNewBurst) {
+			printf("Starting ADCS burst measurements\n");
+			error = takeADCSBurstMeasurements();
+			if (error != 0) {
+				printf("Failed to capture ADCS measurements...\n");
+			} else {
+				printf("Successfully captured ADCS measurements.\n");
+			}
+		}
+
+		// TODO: Call this during downlink to get ADCS burst results
+		uint8_t adcsReadyForDownlink = !getADCSReadyForNewBurstState();
+		if (adcsReadyForDownlink) {
+			adcs_detection_results_t * adcsResults = getADCSBurstResults();
+			if (adcsResults != NULL) {
+				printf("Number of valid measurements: %d\n", adcsResults->validMeasurementsCount);
+
+				for (int i = 0; i < adcsResults->validMeasurementsCount; i++) {
+					printf("Sun timestamp: %lu\n", adcsResults->results[i].sunTimestamp);
+					printf("Sun angles: %i | %i\n", adcsResults->results[i].sunAlphaAngle, adcsResults->results[i].sunBetaAngle);
+					printf("Earth timestamp: %lu\n", adcsResults->results[i].nadirTimestamp);
+					printf("Earth angles: %i | %i\n", adcsResults->results[i].nadirAlphaAngle, adcsResults->results[i].nadirBetaAngle);
+				}
+			}
+		}
+
+
+		printf("\nAdcsCaptureTask(): Finished task.\n");
+
+		if (cubeSenseIsInUse) {
+			// CubeSense was in use, wait only for a small delay to retry task
+			vTaskDelay(ADCS_CAPTURE_TASK_SHORT_DELAY_MS);
+		} else {
+			// Normal operations with normal delay between task execution
+			//vTaskDelay(ADCS_CAPTURE_TASK_NORMAL_DELAY_MS);
+			vTaskDelay(10000);
+		}
 	}
 }

--- a/radsat-sk/src/tasks/RAdcsCaptureTask.c
+++ b/radsat-sk/src/tasks/RAdcsCaptureTask.c
@@ -36,8 +36,11 @@ void AdcsCaptureTask(void* parameters) {
 	// ignore the input parameter
 	(void)parameters;
 
+	// Set the default automatic ADCS capture interval
+	setADCSCaptureInterval(ADCS_CAPTURE_TASK_NORMAL_DELAY_MS);
+
 	// Initialize the ADCS capture settings (5 measurements, 5 seconds between measurements)
-	setADCSCaptureSettings(5, 5000);
+	setADCSBurstSettings(5, 5000);
 
 	while (1) {
 
@@ -86,7 +89,7 @@ void AdcsCaptureTask(void* parameters) {
 			vTaskDelay(ADCS_CAPTURE_TASK_SHORT_DELAY_MS);
 		} else {
 			// Normal operations with normal delay between task execution
-			//vTaskDelay(ADCS_CAPTURE_TASK_NORMAL_DELAY_MS);
+			//vTaskDelay(getADCSCaptureInterval());
 			vTaskDelay(10000);
 		}
 	}

--- a/radsat-sk/src/tasks/RAdcsCaptureTask.c
+++ b/radsat-sk/src/tasks/RAdcsCaptureTask.c
@@ -50,7 +50,6 @@ void AdcsCaptureTask(void* parameters) {
 
 		// Check if CubeSense is already in use (1) or not (0)
 		uint8_t cubeSenseIsInUse = getCubeSenseUsageState();
-		printf("AdcsCaptureTask(): cubeSenseIsInUse = %d\n", cubeSenseIsInUse);
 
 		// Check if ready for a new ADCS burst measurements (1) or not (0)
 		uint8_t adcsReadyForNewBurst = getADCSReadyForNewBurstState();
@@ -60,37 +59,15 @@ void AdcsCaptureTask(void* parameters) {
 			error = takeADCSBurstMeasurements();
 			if (error != 0) {
 				printf("Failed to capture ADCS measurements...\n");
-			} else {
-				printf("Successfully captured ADCS measurements.\n");
 			}
 		}
-
-		// TODO: Call this during downlink to get ADCS burst results
-		uint8_t adcsReadyForDownlink = !getADCSReadyForNewBurstState();
-		if (adcsReadyForDownlink) {
-			adcs_detection_results_t * adcsResults = getADCSBurstResults();
-			if (adcsResults != NULL) {
-				printf("Number of valid measurements: %d\n", adcsResults->validMeasurementsCount);
-
-				for (int i = 0; i < adcsResults->validMeasurementsCount; i++) {
-					printf("Sun timestamp: %lu\n", adcsResults->results[i].sunTimestamp);
-					printf("Sun angles: %i | %i\n", adcsResults->results[i].sunAlphaAngle, adcsResults->results[i].sunBetaAngle);
-					printf("Earth timestamp: %lu\n", adcsResults->results[i].nadirTimestamp);
-					printf("Earth angles: %i | %i\n", adcsResults->results[i].nadirAlphaAngle, adcsResults->results[i].nadirBetaAngle);
-				}
-			}
-		}
-
-
-		printf("\nAdcsCaptureTask(): Finished task.\n");
 
 		if (cubeSenseIsInUse) {
 			// CubeSense was in use, wait only for a small delay to retry task
 			vTaskDelay(ADCS_CAPTURE_TASK_SHORT_DELAY_MS);
 		} else {
 			// Normal operations with normal delay between task execution
-			//vTaskDelay(getADCSCaptureInterval());
-			vTaskDelay(10000);
+			vTaskDelay(getADCSCaptureInterval());
 		}
 	}
 }

--- a/radsat-sk/src/tasks/RImageCaptureTask.c
+++ b/radsat-sk/src/tasks/RImageCaptureTask.c
@@ -5,21 +5,25 @@
  */
 
 #include <RImageCaptureTask.h>
+#include <RCameraService.h>
 #include <RCommon.h>
-#include <RCamera.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <string.h>
 
 
 /***************************************************************************************************
                                    DEFINITIONS & PRIVATE GLOBALS
 ***************************************************************************************************/
 
-/** How many images to capture per week. */
-#define IMAGE_CAPTURES_PER_WEEK	(1)
+/** How many images to capture per day. */
+#define IMAGE_CAPTURES_PER_DAY					(1)
 
-/** Image Capture Task delay (in ms). */
-#define IMAGE_CAPTURE_TASK_DELAY_MS	(MS_PER_WEEK / IMAGE_CAPTURES_PER_WEEK)
+/** Image Capture Task normal delay (in ms). */
+#define IMAGE_CAPTURE_TASK_NORMAL_DELAY_MS		(MS_PER_DAY / IMAGE_CAPTURES_PER_DAY)
+
+/** Image Capture Task short delay (in ms), used when task couldn't execute because CubeSense is in use. */
+#define IMAGE_CAPTURE_TASK_SHORT_DELAY_MS		(10000)
 
 
 /***************************************************************************************************
@@ -27,22 +31,148 @@
 ***************************************************************************************************/
 
 void ImageCaptureTask(void* parameters) {
+	int error;
 
 	// ignore the input parameter
 	(void)parameters;
 
+	// Set the default automatic image capture interval
+	setImageCaptureInterval(IMAGE_CAPTURE_TASK_NORMAL_DELAY_MS);
+
 	while (1) {
 
-		// TODO: implement image capture
+		printf("Image capture interval = %i\n", getImageCaptureInterval());
 
-		debugPrint("ImageCaptureTask(): About to capture an image.\n");
+		// TODO: Uncomment function call when Brian's branch will be ready/merged
+		// Check if satellite is currently in downlink/uplink mode (1) or not (0)
+		uint8_t commIsActive = 0; //communicationPassModeActive();
 
-		// TODO
-		// To initialize an image buffer, use --> "initializeNewImage(...)"
-		// To take a picture, use --------------> "captureImage(...)"
-		// To download a picture, use ----------> "downloadImage(...)"
+		// Check if CubeSense is already in use (1) or not (0)
+		uint8_t cubeSenseIsInUse = getCubeSenseUsageState();
+		printf("ImageCaptureTask(): cubeSenseIsInUse = %d\n", cubeSenseIsInUse);
 
-		vTaskDelay(IMAGE_CAPTURE_TASK_DELAY_MS);
+		if (!commIsActive && !cubeSenseIsInUse) {
+			// Check if ready for a new image capture
+			if (getImageReadyForNewCaptureState()) {
+				printf("READY for new image capture\n");
+
+				// Request a new capture using the Earth sensor and SRAM2
+				error = requestImageCaptureAndDetect(NADIR_SENSOR, SRAM2);
+				if (error != SUCCESS) {
+					printf("Error capturing an image.\n");
+				} else {
+					printf("Image captured successfully!\n");
+
+					// Start a task to download the image
+					uint8_t imageSize = getImageDownloadSize();
+					printf("Image download size = %i\n", imageSize);
+					error = requestImageDownload(SRAM2, imageSize);
+					if (error != SUCCESS) {
+						printf("Error starting image download.\n");
+					} else {
+						printf("Image download has started!\n");
+					}
+				}
+			} else {
+				printf("NOT READY for new image capture\n");
+
+				// No request for a new capture and image not yet ready
+				// for downlink, so retry to download the image
+				if (!getImageReadyForDownlinkState()) {
+					uint8_t imageSize = getImageDownloadSize();
+					printf("Image download size = %i\n", imageSize);
+					error = requestImageDownload(SRAM2, imageSize);
+					if (error != SUCCESS) {
+						printf("Error starting image download.\n");
+					} else {
+						printf("Image download has started!\n");
+					}
+				}
+			}
+		}
+
+
+		// TODO: Call this during downlink to get camera frames one by one
+		// Validate that an image is ready for downlink
+		if (getImageReadyForDownlinkState()) {
+			printf("Image is READY for downlink\n");
+
+			uint16_t imageFramesCount = getImageFramesCount();
+			printf("Number of frames to downlink: %i\n", imageFramesCount);
+			if (imageFramesCount > 0) {
+				//uint8_t frame[128] = {0};
+
+				/*for (int frameIndex = 0; frameIndex < imageFramesCount; frameIndex++) {
+					uint8_t frameSize = imageTransferNextFrame(&frame);
+					if (frameSize == 0) {
+						printf("Error getting frame #%i (frame of size 0)\n", frameIndex);
+						break;
+					}
+				}*/
+
+				/*printf("Get first frame\n");
+				uint8_t frameSize = imageTransferNextFrame(&frame);
+				if (frameSize == 0) {
+					printf("Error getting frame #%i (frame of size 0)\n", 0);
+					break;
+				} else {
+					for	(int i = 0; i < 128; i++) {
+						printf("%i, ", frame[i]);
+					}
+					printf("\n");
+				}
+
+				printf("Get frame #10\n");
+				frameSize = imageTransferSpecificFrame(&frame, 10);
+				if (frameSize == 0) {
+					printf("Error getting frame #%i (frame of size 0)\n", 10);
+					break;
+				} else {
+					for	(int i = 0; i < 128; i++) {
+						printf("%i, ", frame[i]);
+					}
+					printf("\n");
+				}
+
+				printf("Set index and get frame #20\n");
+				setImageTransferFrameIndex(19);
+				frameSize = imageTransferNextFrame(&frame);
+				if (frameSize == 0) {
+					printf("Error getting frame #%i (frame of size 0)\n", 20);
+					break;
+				} else {
+					for	(int i = 0; i < 128; i++) {
+						printf("%i, ", frame[i]);
+					}
+					printf("\n");
+				}
+
+				printf("Get current frame\n");
+				frameSize = imageTransferCurrentFrame(&frame);
+				if (frameSize == 0) {
+					printf("Error getting frame #%i (frame of size 0)\n", 20);
+					break;
+				} else {
+					for	(int i = 0; i < 128; i++) {
+						printf("%i, ", frame[i]);
+					}
+					printf("\n");
+				}*/
+			}
+		} else {
+			printf("NO image is ready for downlink\n");
+		}
+
+		printf("\nImageCaptureTask(): Finished task.\n");
+
+		if (cubeSenseIsInUse) {
+			// CubeSense was in use, wait only for a small delay to retry task
+			vTaskDelay(IMAGE_CAPTURE_TASK_SHORT_DELAY_MS);
+		} else {
+			// Normal operations with normal delay between task execution
+			//vTaskDelay(getImageCaptureInterval());
+			vTaskDelay(10000);
+		}
 	}
 }
 

--- a/radsat-sk/src/tasks/RImageCaptureTask.c
+++ b/radsat-sk/src/tasks/RImageCaptureTask.c
@@ -41,15 +41,12 @@ void ImageCaptureTask(void* parameters) {
 
 	while (1) {
 
-		printf("Image capture interval = %i\n", getImageCaptureInterval());
-
 		// TODO: Uncomment function call when Brian's branch will be ready/merged
 		// Check if satellite is currently in downlink/uplink mode (1) or not (0)
 		uint8_t commIsActive = 0; //communicationPassModeActive();
 
 		// Check if CubeSense is already in use (1) or not (0)
 		uint8_t cubeSenseIsInUse = getCubeSenseUsageState();
-		printf("ImageCaptureTask(): cubeSenseIsInUse = %d\n", cubeSenseIsInUse);
 
 		if (!commIsActive && !cubeSenseIsInUse) {
 			// Check if ready for a new image capture
@@ -61,16 +58,13 @@ void ImageCaptureTask(void* parameters) {
 				if (error != SUCCESS) {
 					printf("Error capturing an image.\n");
 				} else {
-					printf("Image captured successfully!\n");
-
-					// Start a task to download the image
+					// Successful image capture, proceed to
+					// start a task to download the image
 					uint8_t imageSize = getImageDownloadSize();
 					printf("Image download size = %i\n", imageSize);
 					error = requestImageDownload(SRAM2, imageSize);
 					if (error != SUCCESS) {
 						printf("Error starting image download.\n");
-					} else {
-						printf("Image download has started!\n");
 					}
 				}
 			} else {
@@ -80,103 +74,20 @@ void ImageCaptureTask(void* parameters) {
 				// for downlink, so retry to download the image
 				if (!getImageReadyForDownlinkState()) {
 					uint8_t imageSize = getImageDownloadSize();
-					printf("Image download size = %i\n", imageSize);
 					error = requestImageDownload(SRAM2, imageSize);
 					if (error != SUCCESS) {
 						printf("Error starting image download.\n");
-					} else {
-						printf("Image download has started!\n");
 					}
 				}
 			}
 		}
-
-
-		// TODO: Call this during downlink to get camera frames one by one
-		// Validate that an image is ready for downlink
-		if (getImageReadyForDownlinkState()) {
-			printf("Image is READY for downlink\n");
-
-			uint16_t imageFramesCount = getImageFramesCount();
-			printf("Number of frames to downlink: %i\n", imageFramesCount);
-			if (imageFramesCount > 0) {
-				image_frame_t frame = {0};
-				for (int i = 0; i < imageFramesCount; i++) {
-					uint8_t frameSize = imageTransferNextFrame(&frame);
-					if (frameSize == 0) {
-						printf("Error getting frame #%i (frame of size 0)...\n", i);
-						break;
-					} else {
-						printf("Frame #%i copied successfully: ", frame.frameIndex);
-						for	(int j = 0; j < 9; j++) {
-							printf("%i, ", frame.image_bytes[j]);
-						}
-						printf("%i\n", frame.image_bytes[9]);
-					}
-				}
-
-				/*printf("Get first frame\n");
-				uint8_t frameSize = imageTransferNextFrame(&frame);
-				if (frameSize == 0) {
-					printf("Error getting frame #%i (frame of size 0)\n", 0);
-					break;
-				} else {
-					for	(int i = 0; i < 128; i++) {
-						printf("%i, ", frame[i]);
-					}
-					printf("\n");
-				}
-
-				printf("Get frame #10\n");
-				frameSize = imageTransferSpecificFrame(&frame, 10);
-				if (frameSize == 0) {
-					printf("Error getting frame #%i (frame of size 0)\n", 10);
-					break;
-				} else {
-					for	(int i = 0; i < 128; i++) {
-						printf("%i, ", frame[i]);
-					}
-					printf("\n");
-				}
-
-				printf("Set index and get frame #20\n");
-				setImageTransferFrameIndex(19);
-				frameSize = imageTransferNextFrame(&frame);
-				if (frameSize == 0) {
-					printf("Error getting frame #%i (frame of size 0)\n", 20);
-					break;
-				} else {
-					for	(int i = 0; i < 128; i++) {
-						printf("%i, ", frame[i]);
-					}
-					printf("\n");
-				}
-
-				printf("Get current frame\n");
-				frameSize = imageTransferCurrentFrame(&frame);
-				if (frameSize == 0) {
-					printf("Error getting frame #%i (frame of size 0)\n", 20);
-					break;
-				} else {
-					for	(int i = 0; i < 128; i++) {
-						printf("%i, ", frame[i]);
-					}
-					printf("\n");
-				}*/
-			}
-		} else {
-			printf("NO image is ready for downlink\n");
-		}
-
-		printf("\nImageCaptureTask(): Finished task.\n");
 
 		if (cubeSenseIsInUse) {
 			// CubeSense was in use, wait only for a small delay to retry task
 			vTaskDelay(IMAGE_CAPTURE_TASK_SHORT_DELAY_MS);
 		} else {
 			// Normal operations with normal delay between task execution
-			//vTaskDelay(getImageCaptureInterval());
-			vTaskDelay(10000);
+			vTaskDelay(getImageCaptureInterval());
 		}
 	}
 }

--- a/radsat-sk/src/tasks/RImageCaptureTask.c
+++ b/radsat-sk/src/tasks/RImageCaptureTask.c
@@ -100,15 +100,20 @@ void ImageCaptureTask(void* parameters) {
 			uint16_t imageFramesCount = getImageFramesCount();
 			printf("Number of frames to downlink: %i\n", imageFramesCount);
 			if (imageFramesCount > 0) {
-				//uint8_t frame[128] = {0};
-
-				/*for (int frameIndex = 0; frameIndex < imageFramesCount; frameIndex++) {
+				image_frame_t frame = {0};
+				for (int i = 0; i < imageFramesCount; i++) {
 					uint8_t frameSize = imageTransferNextFrame(&frame);
 					if (frameSize == 0) {
-						printf("Error getting frame #%i (frame of size 0)\n", frameIndex);
+						printf("Error getting frame #%i (frame of size 0)...\n", i);
 						break;
+					} else {
+						printf("Frame #%i copied successfully: ", frame.frameIndex);
+						for	(int j = 0; j < 9; j++) {
+							printf("%i, ", frame.image_bytes[j]);
+						}
+						printf("%i\n", frame.image_bytes[9]);
 					}
-				}*/
+				}
 
 				/*printf("Get first frame\n");
 				uint8_t frameSize = imageTransferNextFrame(&frame);


### PR DESCRIPTION
**Description of Changes**
The bulk of the changes in this Pull Request are focused around the new `RCameraService.c`. This file bridges the low-level functions used to interact with the CubeSense board, and the system tasks executing the normal satellite operations. `RCameraService.c` contains functions for both ADCS detection and image capture.

Implementation has been done in `RAdcsCaptureTask.c` and `RImageCaptureTask.c` for the automatic capture of ADCS measurements and the automatic capture and download of an image, respectively. Each are using settings (ex: task delay) that can be customized via a telecommand. More details are available on a flow diagram provided by email.

**Communication with the Ground Station**:
Implementation of telecommands or downlink/uplink is not part of this Pull Request. A list of telecommands needed to control the cameras has been sent by email and will need to be implemented.

- **ADCS measurements downlink**:
Automatic ADCS capture executes a burst of measurements (default is 5), where resulting alpha/beta angles are available only if the CubeSense detection algorithm was successful. Inside the ADCS result struct, the number of successful detections will be available in the field `validMeasurementsCount`, which can be used to iterate in the `results` array:
```
// Validate that ADCS results are available
uint8_t adcsReadyForDownlink = !getADCSReadyForNewBurstState();
if (adcsReadyForDownlink) {
    // Get the ADCS burst results
    adcs_detection_results_t * adcsResults = getADCSBurstResults();
    if (adcsResults != NULL) {
        // TODO
        // The number of valid measurements is available in: adcsResults->validMeasurementsCount
        // Results are stored in the following array (dynamic size): adcsResults->results
    }
}
```

Once downlink is considered complete and the stored ADCS results are no longer needed, the function `setADCSReadyForNewBurst()` needs to be called to restart the automatic ADCS capture.

- **Image frames downlink**:
Image capture and download will store an image in OBC memory, corresponding to a specific download size. The download size can be changed via telecommand. After an image has been downloaded and stored in memory, another download is required if a different image size is needed, which will replace the last stored image. When an image is stored in memory, it is flagged as ready for downlink. In the simplest case, downlink implementation can be done as follows:
```
// Validate that an image is ready for downlink
if (getImageReadyForDownlinkState()) {
    // Get the number of frames in the stored image
    uint16_t imageFramesCount = getImageFramesCount();
    if (imageFramesCount > 0) {
        image_frame_t frame = {0};
        for (int i = 0; i < imageFramesCount; i++) {
            // Get the next image frame using an internal circular index
            // The index increments at the start of this function, so to get frame "0", index should be "-1" (default value)
            uint8_t frameSize = imageTransferNextFrame(&frame);
            if (frameSize == 0) {
                printf("Error getting image frame...\n");
                break;
            }

            // TODO
            // The image frame index received is available in: frame.frameIndex
            // The array of bytes forming the image frame is available in: frame.image_bytes
        }
    }
}
```

If the downlink of an image frame fails, or there is not enough time to downlink all frames during a single pass, then the following `RCameraService` functions are also available to manage the image frame transfer:
- `imageTransferCurrentFrame(&frame)`: Get the image frame at the current internal image frame index.
- `imageTransferSpecificFrame(&frame, frameIndex)`: Get the image frame at the frame index value of `frameIndex`.
- `setImageTransferFrameIndex(frameIndex)`: Update the internal image frame index to the value of argument `frameIndex`. This allows to restart loop execution (using `imageTransferNextFrame()`) at a given index.

Once downlink is considered complete and the stored image is no longer needed, the function `setImageReadyForNewCapture()` needs to be called to restart the automatic image capture.

**Note on Telecommands**:
Comments have been left inside `RTelecommandService.c` to help with the upcoming implementation of some of the function calls to `RCameraService`.